### PR TITLE
Add titanic dataset config

### DIFF
--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -1,0 +1,141 @@
+{
+    "@context": {
+      "@vocab": "https://schema.org/",
+      "ml": "http://mlcommons.org/schema/"
+    },
+  
+    "@type": "Dataset",
+    "@language": "en",
+    "name": "Titanic",
+    "url": "https://www.openml.org/d/40945",
+    "description": "The original Titanic dataset, describing the status of individual passengers on the Titanic.\n\n The titanic data does not contain information from the crew, but it does contain actual ages of half of the passengers. \n\n For more information about how this dataset was constructed: \nhttps://web.archive.org/web/20200802155940/http://biostat.mc.vanderbilt.edu/wiki/pub/Main/DataSets/titanic3info.txt\n\nOther useful information (useful for prices description for example):\nhttp://campus.lakeforest.edu/frank/FILES/MLFfiles/Bio150/Titanic/TitanicMETA.pdf\n\n Also see the following article describing shortcomings of the dataset data:\nhttps://emma-stiefel.medium.com/plugging-holes-in-kaggles-titanic-dataset-an-introduction-to-combining-datasets-with-fuzzywuzzy-60a686699da7\n",
+    "license": "Public",
+    "citation": "The principal source for data about Titanic passengers is the Encyclopedia Titanica (http://www.encyclopedia-titanica.org/). The datasets used here were begun by a variety of researchers. One of the original sources is Eaton & Haas (1994) Titanic: Triumph and Tragedy, Patrick Stephens Ltd, which includes a passenger list created by many researchers and edited by Michael A. Findlay.\n\nThomas Cason of UVa has greatly updated and improved the titanic data frame using the Encyclopedia Titanica and created the dataset here. Some duplicate passengers have been dropped, many errors corrected, many missing ages filled in, and new variables created.\n",
+  
+    "distribution": [
+      {
+        "@type": "FileObject",
+        "name": "passengers",
+        "contentUrl": "https://www.openml.org/data/get_csv/16826755/phpMYEkMl",
+        "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
+        "encodingFormat": "text/csv"
+      }
+    ],
+  
+    "recordSet": [
+      {
+        "@type": "ml:RecordSet",
+        "name": "passengers_list",
+        "description": "The list of passengers. Does not include crew members.\n\nThere seem to be at least two passengers with the same name, so a composite key is used to uniquely identify passengers",
+        "source": "#{passengers}",
+        "key": [
+          "#{name}",
+          "#{age}",
+          "#{gender}",
+          "#{embarked}",
+          "#{home_destination}"
+        ],
+        "field": [
+          {
+            "name": "name",
+            "description": "Name of the passenger",
+            "@type": "ml:Field",
+            "dataType": "Text",
+            "source": "#{passengers/name}"
+          },
+          {
+            "name": "gender",
+            "description": "Gender of passenger (0: Male, 1: Female)",
+            "@type": "ml:Field",
+            "dataType": "Integer",
+            "source": "#{passengers/sex}"
+          },
+          {
+            "name": "age",
+            "description": "Age of passenger at time of death.",
+            "@type": "ml:Field",
+            "dataType": "Integer",
+            "source": "#{passengers/age}"
+          },
+          {
+            "name": "survived",
+            "description": "Survival status of passenger (0: Lost, 1: Saved)",
+            "@type": "ml:Field",
+            "dataType": "Integer",
+            "source": "#{passengers/survived}"
+          },
+          {
+            "name": "pclass",
+            "description": "Passenger Class (1st/2nd/3rd)",
+            "@type": "ml:Field",
+            "dataType": "Integer",
+            "source": "#{passengers/pclass}"
+          },
+          {
+            "name": "cabin",
+            "description": "Passenger cabin.",
+            "@type": "ml:Field",
+            "dataType": "Text",
+            "source": "#{passengers/cabin}"
+          },
+          {
+            "name": "embarked",
+            "description": "Port of Embarkation (C: Cherbourg, Q: Queenstown, S: Southampton, ?: Unknown).",
+            "@type": "City/name",
+            "dataType": "Text",
+            "source": "#{passengers/embarked}"
+  
+          },
+          {
+            "name": "fare",
+            "description": "Passenger Fare (British pound)",
+            "@type": "ml:Field",
+            "dataType": "Float",
+            "source": "#{passengers/fare}"
+          },
+          {
+            "name": "home_destination",
+            "description": "Home and destination",
+            "@type": "ml:Field",
+            "dataType": "Text",
+            "source": "#{passengers/home.dest}"
+          },
+          {
+            "name": "ticket",
+            "description": "Ticket Number, may include a letter.",
+            "@type": "ml:Field",
+            "dataType": "Text",
+            "source": "#{passengers/ticket}"
+          },
+          {
+            "name": "num_parents_children",
+            "description": "Number of Parents/Children Aboard",
+            "@type": "ml:Field",
+            "dataType": "Integer",
+            "source": "#{passengers/parch}"
+          },
+          {
+            "name": "num_siblings_spouses",
+            "description": "Number of Siblings/Spouses Aboard",
+            "@type": "ml:Field",
+            "dataType": "Integer",
+            "source": "#{passengers/sibsp}"
+          },
+          {
+            "name": "boat",
+            "description": "Lifeboat used by passenger",
+            "@type": "ml:Field",
+            "dataType": "Text",
+            "source": "#{passengers/boat}"
+          },
+          {
+            "name": "body",
+            "description": "Body Identification Number",
+            "@type": "ml:Field",
+            "dataType": "Integer",
+            "source": "#{passengers/body}"
+          }
+        ]
+      }
+    ]
+  }

--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -15,7 +15,7 @@
     "distribution": [
       {
         "@type": "FileObject",
-        "name": "passengers",
+        "name": "passengers-table",
         "contentUrl": "https://www.openml.org/data/get_csv/16826755/phpMYEkMl",
         "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
         "encodingFormat": "text/csv"
@@ -25,58 +25,58 @@
     "recordSet": [
       {
         "@type": "ml:RecordSet",
-        "name": "passengers_list",
+        "name": "passengers",
         "description": "The list of passengers. Does not include crew members.",
-        "source": "#{passengers}",
+        "source": "#{passengers-table}",
         "field": [
           {
             "name": "name",
             "description": "Name of the passenger",
             "@type": "ml:Field",
             "dataType": "string",
-            "source": "#{passengers/name}"
+            "source": "#{passengers-table/name}"
           },
           {
             "name": "gender",
             "description": "Gender of passenger (0: Male, 1: Female)",
             "@type": "ml:Field",
             "dataType": "integer",
-            "source": "#{passengers/sex}"
+            "source": "#{passengers-table/sex}"
           },
           {
             "name": "age",
             "description": "Age of passenger at time of death.",
             "@type": "ml:Field",
             "dataType": "integer",
-            "source": "#{passengers/age}"
+            "source": "#{passengers-table/age}"
           },
           {
             "name": "survived",
             "description": "Survival status of passenger (0: Lost, 1: Saved)",
             "@type": "ml:Field",
             "dataType": "integer",
-            "source": "#{passengers/survived}"
+            "source": "#{passengers-table/survived}"
           },
           {
             "name": "pclass",
             "description": "Passenger Class (1st/2nd/3rd)",
             "@type": "ml:Field",
             "dataType": "integer",
-            "source": "#{passengers/pclass}"
+            "source": "#{passengers-table/pclass}"
           },
           {
             "name": "cabin",
             "description": "Passenger cabin.",
             "@type": "ml:Field",
             "dataType": "string",
-            "source": "#{passengers/cabin}"
+            "source": "#{passengers-table/cabin}"
           },
           {
             "name": "embarked",
             "description": "Port of Embarkation (C: Cherbourg, Q: Queenstown, S: Southampton, ?: Unknown).",
             "@type": "City/name",
             "dataType": "string",
-            "source": "#{passengers/embarked}"
+            "source": "#{passengers-table/embarked}"
   
           },
           {
@@ -84,49 +84,49 @@
             "description": "Passenger Fare (British pound)",
             "@type": "ml:Field",
             "dataType": "Float",
-            "source": "#{passengers/fare}"
+            "source": "#{passengers-table/fare}"
           },
           {
             "name": "home_destination",
             "description": "Home and destination",
             "@type": "ml:Field",
             "dataType": "string",
-            "source": "#{passengers/home.dest}"
+            "source": "#{passengers-table/home.dest}"
           },
           {
             "name": "ticket",
             "description": "Ticket Number, may include a letter.",
             "@type": "ml:Field",
             "dataType": "string",
-            "source": "#{passengers/ticket}"
+            "source": "#{passengers-table/ticket}"
           },
           {
             "name": "num_parents_children",
             "description": "Number of Parents/Children Aboard",
             "@type": "ml:Field",
             "dataType": "integer",
-            "source": "#{passengers/parch}"
+            "source": "#{passengers-table/parch}"
           },
           {
             "name": "num_siblings_spouses",
             "description": "Number of Siblings/Spouses Aboard",
             "@type": "ml:Field",
             "dataType": "integer",
-            "source": "#{passengers/sibsp}"
+            "source": "#{passengers-table/sibsp}"
           },
           {
             "name": "boat",
             "description": "Lifeboat used by passenger",
             "@type": "ml:Field",
             "dataType": "string",
-            "source": "#{passengers/boat}"
+            "source": "#{passengers-table/boat}"
           },
           {
             "name": "body",
             "description": "Body Identification Number",
             "@type": "ml:Field",
             "dataType": "integer",
-            "source": "#{passengers/body}"
+            "source": "#{passengers-table/body}"
           }
         ]
       }

--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -1,6 +1,7 @@
 {
     "@context": {
       "@vocab": "https://schema.org/",
+      "csvw": "http://www.w3.org/ns/csvw",
       "ml": "http://mlcommons.org/schema/"
     },
   
@@ -33,49 +34,49 @@
             "name": "name",
             "description": "Name of the passenger",
             "@type": "ml:Field",
-            "dataType": "string",
+            "dataType": "csvw:string",
             "source": "#{passengers-table/name}"
           },
           {
             "name": "gender",
             "description": "Gender of passenger (0: Male, 1: Female)",
             "@type": "ml:Field",
-            "dataType": "integer",
+            "dataType": "csvw:integer",
             "source": "#{passengers-table/sex}"
           },
           {
             "name": "age",
             "description": "Age of passenger at time of death.",
             "@type": "ml:Field",
-            "dataType": "integer",
+            "dataType": "csvw:integer",
             "source": "#{passengers-table/age}"
           },
           {
             "name": "survived",
             "description": "Survival status of passenger (0: Lost, 1: Saved)",
             "@type": "ml:Field",
-            "dataType": "integer",
+            "dataType": "csvw:integer",
             "source": "#{passengers-table/survived}"
           },
           {
             "name": "pclass",
             "description": "Passenger Class (1st/2nd/3rd)",
             "@type": "ml:Field",
-            "dataType": "integer",
+            "dataType": "csvw:integer",
             "source": "#{passengers-table/pclass}"
           },
           {
             "name": "cabin",
             "description": "Passenger cabin.",
             "@type": "ml:Field",
-            "dataType": "string",
+            "dataType": "csvw:string",
             "source": "#{passengers-table/cabin}"
           },
           {
             "name": "embarked",
             "description": "Port of Embarkation (C: Cherbourg, Q: Queenstown, S: Southampton, ?: Unknown).",
             "@type": "City/name",
-            "dataType": "string",
+            "dataType": "csvw:string",
             "source": "#{passengers-table/embarked}"
   
           },
@@ -90,42 +91,42 @@
             "name": "home_destination",
             "description": "Home and destination",
             "@type": "ml:Field",
-            "dataType": "string",
+            "dataType": "csvw:string",
             "source": "#{passengers-table/home.dest}"
           },
           {
             "name": "ticket",
             "description": "Ticket Number, may include a letter.",
             "@type": "ml:Field",
-            "dataType": "string",
+            "dataType": "csvw:string",
             "source": "#{passengers-table/ticket}"
           },
           {
             "name": "num_parents_children",
             "description": "Number of Parents/Children Aboard",
             "@type": "ml:Field",
-            "dataType": "integer",
+            "dataType": "csvw:integer",
             "source": "#{passengers-table/parch}"
           },
           {
             "name": "num_siblings_spouses",
             "description": "Number of Siblings/Spouses Aboard",
             "@type": "ml:Field",
-            "dataType": "integer",
+            "dataType": "csvw:integer",
             "source": "#{passengers-table/sibsp}"
           },
           {
             "name": "boat",
             "description": "Lifeboat used by passenger",
             "@type": "ml:Field",
-            "dataType": "string",
+            "dataType": "csvw:string",
             "source": "#{passengers-table/boat}"
           },
           {
             "name": "body",
             "description": "Body Identification Number",
             "@type": "ml:Field",
-            "dataType": "integer",
+            "dataType": "csvw:integer",
             "source": "#{passengers-table/body}"
           }
         ]

--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -26,15 +26,8 @@
       {
         "@type": "ml:RecordSet",
         "name": "passengers_list",
-        "description": "The list of passengers. Does not include crew members.\n\nThere seem to be at least two passengers with the same name, so a composite key is used to uniquely identify passengers",
+        "description": "The list of passengers. Does not include crew members.",
         "source": "#{passengers}",
-        "key": [
-          "#{name}",
-          "#{age}",
-          "#{gender}",
-          "#{embarked}",
-          "#{home_destination}"
-        ],
         "field": [
           {
             "name": "name",

--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -40,49 +40,49 @@
             "name": "name",
             "description": "Name of the passenger",
             "@type": "ml:Field",
-            "dataType": "Text",
+            "dataType": "string",
             "source": "#{passengers/name}"
           },
           {
             "name": "gender",
             "description": "Gender of passenger (0: Male, 1: Female)",
             "@type": "ml:Field",
-            "dataType": "Integer",
+            "dataType": "integer",
             "source": "#{passengers/sex}"
           },
           {
             "name": "age",
             "description": "Age of passenger at time of death.",
             "@type": "ml:Field",
-            "dataType": "Integer",
+            "dataType": "integer",
             "source": "#{passengers/age}"
           },
           {
             "name": "survived",
             "description": "Survival status of passenger (0: Lost, 1: Saved)",
             "@type": "ml:Field",
-            "dataType": "Integer",
+            "dataType": "integer",
             "source": "#{passengers/survived}"
           },
           {
             "name": "pclass",
             "description": "Passenger Class (1st/2nd/3rd)",
             "@type": "ml:Field",
-            "dataType": "Integer",
+            "dataType": "integer",
             "source": "#{passengers/pclass}"
           },
           {
             "name": "cabin",
             "description": "Passenger cabin.",
             "@type": "ml:Field",
-            "dataType": "Text",
+            "dataType": "string",
             "source": "#{passengers/cabin}"
           },
           {
             "name": "embarked",
             "description": "Port of Embarkation (C: Cherbourg, Q: Queenstown, S: Southampton, ?: Unknown).",
             "@type": "City/name",
-            "dataType": "Text",
+            "dataType": "string",
             "source": "#{passengers/embarked}"
   
           },
@@ -97,42 +97,42 @@
             "name": "home_destination",
             "description": "Home and destination",
             "@type": "ml:Field",
-            "dataType": "Text",
+            "dataType": "string",
             "source": "#{passengers/home.dest}"
           },
           {
             "name": "ticket",
             "description": "Ticket Number, may include a letter.",
             "@type": "ml:Field",
-            "dataType": "Text",
+            "dataType": "string",
             "source": "#{passengers/ticket}"
           },
           {
             "name": "num_parents_children",
             "description": "Number of Parents/Children Aboard",
             "@type": "ml:Field",
-            "dataType": "Integer",
+            "dataType": "integer",
             "source": "#{passengers/parch}"
           },
           {
             "name": "num_siblings_spouses",
             "description": "Number of Siblings/Spouses Aboard",
             "@type": "ml:Field",
-            "dataType": "Integer",
+            "dataType": "integer",
             "source": "#{passengers/sibsp}"
           },
           {
             "name": "boat",
             "description": "Lifeboat used by passenger",
             "@type": "ml:Field",
-            "dataType": "Text",
+            "dataType": "string",
             "source": "#{passengers/boat}"
           },
           {
             "name": "body",
             "description": "Body Identification Number",
             "@type": "ml:Field",
-            "dataType": "Integer",
+            "dataType": "integer",
             "source": "#{passengers/body}"
           }
         ]


### PR DESCRIPTION
This config does not include semantic information, such as for example how to interpret the gender, the embarkation port, etc. This will come later.

Considerations which might be worth a discussion:
 - The quality of the data really could be improved. I have added some information in the description but maybe we can come up with some more precise annotations.
 - Aliases: when naming the fields in a recordSet, would it make sense to allow for aliases? In titanic original dataset, some field names aren't very explicit (eg: "parch"), so I renamed them (eg: "num_parents_children"). That's discutable, but an alias would allow to keep both.