### PR TITLE
Add contentSize to titanic FileObject

### DIFF
--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -18,6 +18,7 @@
         "@type": "FileObject",
         "name": "passengers-table",
         "contentUrl": "https://www.openml.org/data/get_csv/16826755/phpMYEkMl",
+        "contentSize": "117743B",
         "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
         "encodingFormat": "text/csv"
       }
@@ -133,3 +134,4 @@
       }
     ]
   }
+

--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -18,7 +18,7 @@
         "@type": "FileObject",
         "name": "passengers-table",
         "contentUrl": "https://www.openml.org/data/get_csv/16826755/phpMYEkMl",
-        "contentSize": "117743B",
+        "contentSize": "117743 B",
         "sha256": "c617db2c7470716250f6f001be51304c76bcc8815527ab8bae734bdca0735737",
         "encodingFormat": "text/csv"
       }


### PR DESCRIPTION
https://schema.org/contentSize is not very explicit on how the size unit should be specified.
https://github.com/schemaorg/schemaorg/issues/869 is the corresponding issue on schema.org.