### PR TITLE
Titanic dataset: add enum semantic definitions for gender and embarkation port, using inlined data

### DIFF
--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -1,21 +1,21 @@
 {
     "@context": {
-      "@vocab": "https://schema.org/",
-      "csvw": "http://www.w3.org/ns/csvw",
-      "ml": "http://mlcommons.org/schema/"
+      "sc": "https://schema.org/",
+      "ml": "http://mlcommons.org/schema/",
+      "wd": "https://www.wikidata.org/wiki/Q"
     },
-  
-    "@type": "Dataset",
+
+    "@type": "sc:Dataset",
     "@language": "en",
     "name": "Titanic",
     "url": "https://www.openml.org/d/40945",
     "description": "The original Titanic dataset, describing the status of individual passengers on the Titanic.\n\n The titanic data does not contain information from the crew, but it does contain actual ages of half of the passengers. \n\n For more information about how this dataset was constructed: \nhttps://web.archive.org/web/20200802155940/http://biostat.mc.vanderbilt.edu/wiki/pub/Main/DataSets/titanic3info.txt\n\nOther useful information (useful for prices description for example):\nhttp://campus.lakeforest.edu/frank/FILES/MLFfiles/Bio150/Titanic/TitanicMETA.pdf\n\n Also see the following article describing shortcomings of the dataset data:\nhttps://emma-stiefel.medium.com/plugging-holes-in-kaggles-titanic-dataset-an-introduction-to-combining-datasets-with-fuzzywuzzy-60a686699da7\n",
     "license": "Public",
     "citation": "The principal source for data about Titanic passengers is the Encyclopedia Titanica (http://www.encyclopedia-titanica.org/). The datasets used here were begun by a variety of researchers. One of the original sources is Eaton & Haas (1994) Titanic: Triumph and Tragedy, Patrick Stephens Ltd, which includes a passenger list created by many researchers and edited by Michael A. Findlay.\n\nThomas Cason of UVa has greatly updated and improved the titanic data frame using the Encyclopedia Titanica and created the dataset here. Some duplicate passengers have been dropped, many errors corrected, many missing ages filled in, and new variables created.\n",
-  
+
     "distribution": [
       {
-        "@type": "FileObject",
+        "@type": "sc:FileObject",
         "name": "passengers-table",
         "contentUrl": "https://www.openml.org/data/get_csv/16826755/phpMYEkMl",
         "contentSize": "117743 B",
@@ -23,8 +23,48 @@
         "encodingFormat": "text/csv"
       }
     ],
-  
+
     "recordSet": [
+      {
+        "@type": "ml:RecordSet",
+        "name": "gender_enums",
+        "description": "Maps gender keys (0, 1) to labeled values.",
+        "key": "#{key}",
+        "field": [
+            { "name": "key", "@type": "ml:Field", "dataType": "sc:Integer" },
+            { "name": "label", "@type": "ml:Field", "dataType": "sc:String" },
+            {
+                "name": "url",
+                "@type": "ml:Field",
+                "dataType": ["sc:Url", "wd:48277"]
+            }
+        ],
+        "data": [
+            { "key": 0, "label": "Male", "url": "wd:6581097" },
+            { "key": 1, "label": "Female", "url": "wd:6581072" }
+        ]
+      },
+      {
+        "@type": "ml:RecordSet",
+        "name": "ports_enums",
+        "description": "Maps Embarkation port initial to labeled values.",
+        "key": "#{key}",
+        "field": [
+            { "name": "key", "@type": "ml:Field", "dataType": "sc:Text" },
+            { "name": "label", "@type": "ml:Field", "dataType": "sc:Text" },
+            {
+                "name": "url",
+                "@type": "ml:Field",
+                "dataType": ["sc:Url", "wd:515"]
+            }
+        ],
+        "data": [
+            { "key": "C", "label": "Cherbourg", "url": "wd:3667188" },
+            { "key": "Q", "label": "Queenstown", "url": "wd:733093" },
+            { "key": "S", "label": "Southampton", "url": "wd:79848" },
+            { "key": "?", "label": "Unknown", "url": "wd:24238356" }
+        ]
+      },
       {
         "@type": "ml:RecordSet",
         "name": "passengers",
@@ -35,51 +75,52 @@
             "name": "name",
             "description": "Name of the passenger",
             "@type": "ml:Field",
-            "dataType": "csvw:string",
+            "dataType": "sc:Text",
             "source": "#{passengers-table/name}"
           },
           {
             "name": "gender",
             "description": "Gender of passenger (0: Male, 1: Female)",
             "@type": "ml:Field",
-            "dataType": "csvw:integer",
-            "source": "#{passengers-table/sex}"
+            "dataType": "sc:Integer",
+            "source": "#{passengers-table/sex}",
+            "references": "#{gender_enums}"
           },
           {
             "name": "age",
             "description": "Age of passenger at time of death.",
             "@type": "ml:Field",
-            "dataType": "csvw:integer",
+            "dataType": "sc:Integer",
             "source": "#{passengers-table/age}"
           },
           {
             "name": "survived",
             "description": "Survival status of passenger (0: Lost, 1: Saved)",
             "@type": "ml:Field",
-            "dataType": "csvw:integer",
+            "dataType": "sc:Integer",
             "source": "#{passengers-table/survived}"
           },
           {
             "name": "pclass",
             "description": "Passenger Class (1st/2nd/3rd)",
             "@type": "ml:Field",
-            "dataType": "csvw:integer",
+            "dataType": "sc:Integer",
             "source": "#{passengers-table/pclass}"
           },
           {
             "name": "cabin",
             "description": "Passenger cabin.",
             "@type": "ml:Field",
-            "dataType": "csvw:string",
+            "dataType": "sc:Text",
             "source": "#{passengers-table/cabin}"
           },
           {
             "name": "embarked",
             "description": "Port of Embarkation (C: Cherbourg, Q: Queenstown, S: Southampton, ?: Unknown).",
-            "@type": "City/name",
-            "dataType": "csvw:string",
-            "source": "#{passengers-table/embarked}"
-  
+            "@type": "ml:Field",
+            "dataType": "sc:Text",
+            "source": "#{passengers-table/embarked}",
+            "references": "#{ports_enums}"
           },
           {
             "name": "fare",
@@ -92,46 +133,45 @@
             "name": "home_destination",
             "description": "Home and destination",
             "@type": "ml:Field",
-            "dataType": "csvw:string",
+            "dataType": "sc:Text",
             "source": "#{passengers-table/home.dest}"
           },
           {
             "name": "ticket",
             "description": "Ticket Number, may include a letter.",
             "@type": "ml:Field",
-            "dataType": "csvw:string",
+            "dataType": "sc:Text",
             "source": "#{passengers-table/ticket}"
           },
           {
             "name": "num_parents_children",
             "description": "Number of Parents/Children Aboard",
             "@type": "ml:Field",
-            "dataType": "csvw:integer",
+            "dataType": "sc:Integer",
             "source": "#{passengers-table/parch}"
           },
           {
             "name": "num_siblings_spouses",
             "description": "Number of Siblings/Spouses Aboard",
             "@type": "ml:Field",
-            "dataType": "csvw:integer",
+            "dataType": "sc:Integer",
             "source": "#{passengers-table/sibsp}"
           },
           {
             "name": "boat",
             "description": "Lifeboat used by passenger",
             "@type": "ml:Field",
-            "dataType": "csvw:string",
+            "dataType": "sc:Text",
             "source": "#{passengers-table/boat}"
           },
           {
             "name": "body",
             "description": "Body Identification Number",
             "@type": "ml:Field",
-            "dataType": "csvw:integer",
+            "dataType": "sc:Integer",
             "source": "#{passengers-table/body}"
           }
         ]
       }
     ]
-  }
-
+}


### PR DESCRIPTION
This change defines two new `recordSet`s:
 1. mapping from gender (0, 1) to labels ("Male", "Female") and their semantic meaning as a wikidata url (eg: https://www.wikidata.org/wiki/Q6581097).
 2. mapping from embarkation port ("C", "Q", "S", "?") to labels and their semantic meaning as a wikidata url. This is a good example of wikidata benefits, as "Queenstown" doesn't refer to the New-Zealand city of that name, but to the Irish city which has since then been renamed Cobh.

The meta semantic types (or classes) - gender and city - are defined together with the dataType. I think we should see this feature as orthogonal to the semantic type: one could be defined without the other, and it would be acceptable I think to have a dataset where a field has both data types picture and url (eg: https://www.wikidata.org/wiki/Q506).

The two new recordsets have their data defined inline, using a simple json notation.

What I like about this change is that the semantic definition of the gender and embarkation_port fields is fairly independent of the data passengers data definition, so one can easily add it at a later stage of the dataset definition...

Other small changes: 
 - Import https://schema.org/ under "sc:" namespace, so it's more obvious when reading the config what comes from there.
 - Switch back from http://www.w3.org/ns/csvw to schema.org for Text and Integer dataTypes, as per https://github.com/mlcommons/datasets_format/commit/bf3813c7d210b0ffaa062382408b9a29c6a0d80e#comments.