### PR TITLE
Implement a first version of the computation graph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,5 +60,6 @@ jobs:
         JSON_FILES=$(python -c "import os; from etils import epath; [print(os.fspath(path)) for path in epath.Path('../../datasets').glob('*/metadata.json')]")
         for file in ${JSON_FILES}
         do
+          echo "Validating ${file}..."
           python scripts/validate.py --file ${file}
         done

--- a/datasets/movielens/metadata.json
+++ b/datasets/movielens/metadata.json
@@ -3,10 +3,7 @@
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
     "ml": "http://mlcommons.org/schema/",
-    "includes": {
-      "@id": "ml:includes",
-      "@type": "@id"
-    },
+    "includes": "ml:includes",
     "recordSet": "ml:RecordSet",
     "field": "ml:Field",
     "subField": "ml:SubField",

--- a/datasets/movielens/metadata.json
+++ b/datasets/movielens/metadata.json
@@ -2,7 +2,21 @@
   "@context": {
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
-    "ml": "http://mlcommons.org/schema/"
+    "ml": "http://mlcommons.org/schema/",
+    "includes": {
+      "@id": "ml:includes",
+      "@type": "@id"
+    },
+    "recordSet": "ml:RecordSet",
+    "field": "ml:Field",
+    "subField": "ml:SubField",
+    "dataType": "ml:dataType",
+    "source": "ml:source",
+    "data": "ml:data",
+    "applyTransform": "ml:applyTransform",
+    "format": "ml:format",
+    "regex": "ml:regex",
+    "separator": "ml:separator"
   },
   "@type": "sc:Dataset",
   "@language": "en",

--- a/datasets/movielens/metadata.json
+++ b/datasets/movielens/metadata.json
@@ -34,42 +34,42 @@
     {
       "name": "ratings-table",
       "@type": "sc:FileObject",
-      "containedIn": "ml-25m-archive",
+      "containedIn": "#{ml-25m-archive}",
       "contentUrl": "ratings.csv",
       "encodingFormat": "text/csv"
     },
     {
       "name": "movies-table",
       "@type": "sc:FileObject",
-      "containedIn": "ml-25m-archive",
+      "containedIn": "#{ml-25m-archive}",
       "contentUrl": "movies.csv",
       "encodingFormat": "text/csv"
     },
     {
       "name": "tags-table",
       "@type": "sc:FileObject",
-      "containedIn": "ml-25m-archive",
+      "containedIn": "#{ml-25m-archive}",
       "contentUrl": "tags.csv",
       "encodingFormat": "text/csv"
     },
     {
       "name": "links-table",
       "@type": "sc:FileObject",
-      "containedIn": "ml-25m-archive",
+      "containedIn": "#{ml-25m-archive}",
       "contentUrl": "links.csv",
       "encodingFormat": "text/csv"
     },
     {
       "name": "genome-scores-table",
       "@type": "sc:FileObject",
-      "containedIn": "ml-25m-archive",
+      "containedIn": "#{ml-25m-archive}",
       "contentUrl": "genome-scores.csv",
       "encodingFormat": "text/csv"
     },
     {
       "name": "genome-tags-table",
       "@type": "sc:FileObject",
-      "containedIn": "ml-25m-archive",
+      "containedIn": "#{ml-25m-archive}",
       "contentUrl": "genome-tags.csv",
       "encodingFormat": "text/csv"
     }

--- a/datasets/pass/metadata.json
+++ b/datasets/pass/metadata.json
@@ -3,10 +3,7 @@
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
     "ml": "http://mlcommons.org/schema/",
-    "includes": {
-      "@id": "ml:includes",
-      "@type": "@id"
-    },
+    "includes": "ml:includes",
     "recordSet": "ml:RecordSet",
     "field": "ml:Field",
     "subField": "ml:SubField",

--- a/datasets/pass/metadata.json
+++ b/datasets/pass/metadata.json
@@ -9,7 +9,14 @@
     },
     "recordSet": "ml:RecordSet",
     "field": "ml:Field",
-    "dataType": "ml:dataType"
+    "subField": "ml:SubField",
+    "dataType": "ml:dataType",
+    "source": "ml:source",
+    "data": "ml:data",
+    "applyTransform": "ml:applyTransform",
+    "format": "ml:format",
+    "regex": "ml:regex",
+    "separator": "ml:separator"
   },
   "@type": "sc:Dataset",
   "@language": "en",

--- a/datasets/pass/metadata.json
+++ b/datasets/pass/metadata.json
@@ -6,7 +6,10 @@
     "includes": {
       "@id": "ml:includes",
       "@type": "@id"
-    }
+    },
+    "recordSet": "ml:RecordSet",
+    "field": "ml:Field",
+    "dataType": "ml:dataType"
   },
   "@type": "sc:Dataset",
   "@language": "en",

--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -3,6 +3,7 @@
       "@vocab": "https://schema.org/",
       "sc": "https://schema.org/",
       "ml": "http://mlcommons.org/schema/",
+      "wd": "https://www.wikidata.org/wiki/Q",
       "includes": "ml:includes",
       "recordSet": "ml:RecordSet",
       "field": "ml:Field",

--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -15,6 +15,9 @@
       "recordSet": {
         "@id": "ml:RecordSet",
         "@type": "@id"
+      },
+      "source": {
+        "@id": "ml:source"
       }
     },
     "@type": "sc:Dataset",
@@ -168,7 +171,7 @@
             "description": "Home and destination",
             "@type": "ml:Field",
             "dataType": "sc:Text",
-            "source": "#{passengers-table/home.dest}"
+            "source": "#{passengers-table/home-dest}"
           },
           {
             "name": "ticket",

--- a/datasets/titanic/metadata.json
+++ b/datasets/titanic/metadata.json
@@ -3,22 +3,17 @@
       "@vocab": "https://schema.org/",
       "sc": "https://schema.org/",
       "ml": "http://mlcommons.org/schema/",
-      "wd": "https://www.wikidata.org/wiki/Q",
-      "dataType": {
-        "@id": "ml:dataType",
-        "@type": "@id"
-      },
-      "field": {
-        "@id": "ml:Field",
-        "@type": "@id"
-      },
-      "recordSet": {
-        "@id": "ml:RecordSet",
-        "@type": "@id"
-      },
-      "source": {
-        "@id": "ml:source"
-      }
+      "includes": "ml:includes",
+      "recordSet": "ml:RecordSet",
+      "field": "ml:Field",
+      "subField": "ml:SubField",
+      "dataType": "ml:dataType",
+      "source": "ml:source",
+      "data": "ml:data",
+      "applyTransform": "ml:applyTransform",
+      "format": "ml:format",
+      "regex": "ml:regex",
+      "separator": "ml:separator"
     },
     "@type": "sc:Dataset",
     "@language": "en",

--- a/python/format/src/computations.py
+++ b/python/format/src/computations.py
@@ -6,32 +6,67 @@ import networkx as nx
 from format.src import graphs_utils
 from format.src.errors import Issues
 from format.src.nodes import (
+    concatenate_uid,
     Field,
     FileObject,
     FileSet,
+    Metadata,
     Node,
     RecordSet,
 )
 
 
-def get_structure_graph(nodes: list[Node]) -> nx.MultiDiGraph():
+def get_entry_nodes(graph: nx.MultiDiGraph) -> list[Node]:
+    """Retrieves the entry nodes (without predecessors) in a graph."""
+    entry_nodes = []
+    for node, indegree in graph.in_degree(graph.nodes()):
+        if indegree == 0:
+            entry_nodes.append(node)
+    return entry_nodes
+
+
+def get_structure_graph(
+    issues: Issues, nodes: list[Node]
+) -> tuple[Node, nx.MultiDiGraph]:
     graph = nx.MultiDiGraph()
+    uid_to_node: Mapping[str, Node] = {}
     for node in nodes:
-        graph.add_node(node.name, node=node)
-        if node.sources:
-            for source in node.sources:
-                graph.add_edge(source[0], node.name)
-        elif node.parent_name is not None:
-            graph.add_edge(node.parent_name, node.name)
-    entry_nodes = [
-        graph.nodes[node]["node"]
-        for node, indegree in graph.in_degree(graph.nodes())
-        if indegree == 0
-    ]
+        if node.uid in uid_to_node:
+            issues.add_error(f"Duplicate node with the same identifier: {node.uid}")
+        uid_to_node[node.uid] = node
+    for node in nodes:
+        if isinstance(node, Metadata):
+            continue
+        parent = uid_to_node[node.parent_uid]
+        graph.add_node(node, parent=parent)
+        # Distribution
+        if isinstance(node, (FileObject, FileSet)) and node.contained_in:
+            for uid in node.contained_in:
+                graph.add_edge(uid_to_node[uid], node)
+        # Fields
+        elif isinstance(node, Field) and node.source:
+            reference = node.source.reference
+            # The source can be either another field...
+            if (uid := concatenate_uid(reference)) in uid_to_node:
+                graph.add_edge(uid_to_node[uid], node)
+            # ...or the source can be a metadata.
+            elif (uid := reference[0]) in uid_to_node:
+                graph.add_edge(uid_to_node[uid], node)
+        # Other nodes
+        elif node.parent_uid is not None:
+            parent = uid_to_node[node.parent_uid]
+            graph.add_edge(parent, node)
+    # `Metadata` are used as the entry node.
+    metadata_node = next((node for node in nodes if isinstance(node, Metadata)), None)
+    if metadata_node is None:
+        issues.add_error("No metadata is defined in the dataset.")
+        return None, graph
+    graph.add_node(metadata_node, parent=None)
+    entry_nodes = get_entry_nodes(graph)
     for node in entry_nodes:
         if isinstance(node, (FileObject, FileSet)):
-            graph.add_edge(node.parent_name, node.name)
-    return graph
+            graph.add_edge(metadata_node, node)
+    return metadata_node, graph
 
 
 @dataclasses.dataclass(frozen=True)
@@ -41,113 +76,95 @@ class Operation:
 
 @dataclasses.dataclass(frozen=True)
 class ComputationGraph:
+    """Graph of dependent operations to execute to generate the dataset."""
+
     issues: Issues
     graph: nx.MultiDiGraph
 
     @classmethod
     def from_nodes(self, issues: Issues, nodes: list[Node]) -> "ComputationGraph":
-        graph = get_structure_graph(nodes)
+        entry_node, graph = get_structure_graph(issues, nodes)
         if not graph.is_directed():
             issues.add_error("Final graph is not directed.")
-        last_operation_for_node: Mapping[str, Operation] = {}
-        graphs_utils.pretty_print_graph(graph)
+        last_operation_for_node: Mapping[Node, Operation] = {}
         operations = nx.MultiDiGraph()
-        entry_nodes = [
-            node_name
-            for node_name, indegree in graph.in_degree(graph.nodes())
-            if indegree == 0
-        ]
-        if len(entry_nodes) != 1:
-            issues.add_error(f"The structure graph has {len(entry_nodes)}. Expected 1.")
-        for layer in nx.bfs_layers(graph, entry_nodes[0]):
-            for node_name in layer:
-                node = graph.nodes[node_name]["node"]
-                predecessors = graph.predecessors(node_name)
+        for layer in nx.bfs_layers(graph, entry_node):
+            for node in layer:
+                predecessors = graph.predecessors(node)
                 for predecessor in predecessors:
                     if predecessor in last_operation_for_node:
-                        last_operation_for_node[node.name] = last_operation_for_node[
+                        last_operation_for_node[node] = last_operation_for_node[
                             predecessor
                         ]
                 if isinstance(node, Field):
-                    if node.sources:
-                        for source in node.sources:
-                            if len(source) != 2:
-                                issues.add_error(f'Wrong source in node "{node.name}"')
-                                continue
-                            source_name, field = source
-                            operation_name = (
-                                "field" if isinstance(node, Field) else "subField"
-                            )
-                            operation = Operation(f"{operation_name}:{field}")
-                            operations.add_edge(
-                                last_operation_for_node[source_name], operation
-                            )
-                            if node.source.apply_transform_regex:
-                                new_operation = Operation("transform-regex")
-                                operations.add_edge(operation, new_operation)
-                                operation = new_operation
-                            if node.source.apply_transform_separator:
-                                new_operation = Operation("transform-separator")
-                                operations.add_edge(operation, new_operation)
-                                operation = new_operation
-                            # TODO(marcenacp): Should keep the recursion?
-                            parent_node = graph.nodes[node.parent_name]["node"]
-                            if isinstance(parent_node, Field) and isinstance(
-                                node, Field
-                            ):
-                                new_operation = Operation(f"field:{parent_node.name}")
-                                operations.add_edge(operation, new_operation)
-                                operation = new_operation
-                                node = parent_node
-                            parent_node = graph.nodes[node.parent_name]["node"]
-                            if isinstance(parent_node, RecordSet):
-                                new_operation = Operation(
-                                    f"record-set:{parent_node.name}"
-                                )
-                                operations.add_edge(operation, new_operation)
-                                operation = new_operation
-                elif isinstance(node, FileObject):
-                    operation = Operation(name=f"download:{node.name}")
-                    operations.add_node(operation)
-                    last_operation_for_node[node.name] = operation
-                    next_node_name = next(graph.neighbors(node_name))
-                    next_node = graph.nodes[next_node_name]["node"]
-                    if (
-                        node.encoding_format == "application/x-tar"
-                        and isinstance(next_node, (FileObject, FileSet))
-                        and next_node.encoding_format != "application/x-tar"
-                    ):
-                        operation = Operation(name=f"extract:{node.name}")
+                    if node.source and not node.has_sub_fields:
+                        if len(node.source.reference) != 2:
+                            issues.add_error(f'Wrong source in node "{node.uid}"')
+                            continue
+                        predecessor = next(graph.predecessors(node))
+                        operation = Operation(f"field:{node.name}")
                         operations.add_edge(
-                            last_operation_for_node[node.name], operation
+                            last_operation_for_node[predecessor], operation
                         )
-                        last_operation_for_node[node.name] = operation
-                elif isinstance(node, (FileObject, FileSet)):
-                    if node.sources:
-                        operation = Operation(name=f"filter:{node.name}")
-                        for source in node.sources:
+                        if node.source.apply_transform_regex:
+                            new_operation = Operation("transform-regex")
+                            operations.add_edge(operation, new_operation)
+                            operation = new_operation
+                        if node.source.apply_transform_separator:
+                            new_operation = Operation("transform-separator")
+                            operations.add_edge(operation, new_operation)
+                            operation = new_operation
+                        last_operation_for_node[node] = operation
+                        parent_node = graph.nodes[node].get("parent")
+                        if isinstance(parent_node, Field) and isinstance(node, Field):
+                            new_operation = Operation(f"field:{parent_node.uid}")
+                            operations.add_edge(operation, new_operation)
+                            operation = new_operation
+                            last_operation_for_node[parent_node] = new_operation
+                            parent_node = graph.nodes[parent_node].get("parent")
+                        if isinstance(parent_node, RecordSet):
+                            new_operation = Operation(f"record-set:{parent_node.uid}")
+                            operations.add_edge(operation, new_operation)
+                            operation = new_operation
+                            last_operation_for_node[parent_node] = new_operation
+                elif isinstance(node, FileObject):
+                    operation = Operation(name=f"download:{node.uid}")
+                    operations.add_node(operation)
+                    last_operation_for_node[node] = operation
+                    for successor in graph.successors(node):
+                        if (
+                            node.encoding_format == "application/x-tar"
+                            and isinstance(successor, (FileObject, FileSet))
+                            and successor.encoding_format != "application/x-tar"
+                        ):
+                            operation = Operation(name=f"extract:{node.uid}")
                             operations.add_edge(
-                                last_operation_for_node[source[0]], operation
+                                last_operation_for_node[node], operation
                             )
-                            last_operation_for_node[source[0]] = operation
-                        last_operation_for_node[node.name] = operation
+                            last_operation_for_node[node] = operation
+                elif isinstance(node, (FileObject, FileSet)):
+                    if node.contained_in:
+                        operation = Operation(name=f"filter:{node.uid}")
+                        for source in graph.predecessors(node):
+                            operations.add_edge(
+                                last_operation_for_node[source], operation
+                            )
+                            last_operation_for_node[source] = operation
+                        last_operation_for_node[node] = operation
 
         # Attach all entry nodes to a single `start` node
-        entry_operations = [
-            operation
-            for operation, indegree in operations.in_degree(operations.nodes())
-            if indegree == 0
-        ]
-        empty_operation = Operation("init")
+        entry_operations = get_entry_nodes(operations)
+        init_operation = Operation("init")
         for entry_operation in entry_operations:
-            operations.add_edge(empty_operation, entry_operation)
+            operations.add_edge(init_operation, entry_operation)
 
+        graphs_utils.pretty_print_graph(operations)
         return ComputationGraph(issues=issues, graph=operations)
 
     def check_graph(self):
         if not self.graph.is_directed():
             self.issues.add_error("Computation graph is not directed.")
-        selfloops = [operation.name for operation, _ in nx.selfloop_edges(self.graph)]
+        selfloops = [operation.uid for operation, _ in nx.selfloop_edges(self.graph)]
         if selfloops:
             self.issues.add_error(
                 f"The following operations refered to themselves: {selfloops}"

--- a/python/format/src/computations.py
+++ b/python/format/src/computations.py
@@ -1,0 +1,20 @@
+import dataclasses
+
+import networkx as nx
+
+from format.src.nodes import Node
+
+
+@dataclasses.dataclass(frozen=True)
+class ComputationGraph(nx.MultiDiGraph):
+    graph: nx.MultiDiGraph
+
+    @classmethod
+    def from_nodes(self, nodes: list[Node]) -> "ComputationGraph":
+        graph = nx.MultiDiGraph()
+        for node in nodes:
+            graph.add_node(node)
+        return ComputationGraph(graph=graph)
+
+    def check_graph(self):
+        pass

--- a/python/format/src/computations.py
+++ b/python/format/src/computations.py
@@ -1,20 +1,154 @@
 import dataclasses
+from typing import Mapping
 
 import networkx as nx
 
-from format.src.nodes import Node
+from format.src import graphs_utils
+from format.src.errors import Issues
+from format.src.nodes import (
+    Field,
+    FileObject,
+    FileSet,
+    Node,
+    RecordSet,
+)
+
+
+def get_structure_graph(nodes: list[Node]) -> nx.MultiDiGraph():
+    graph = nx.MultiDiGraph()
+    for node in nodes:
+        graph.add_node(node.name, node=node)
+        if node.sources:
+            for source in node.sources:
+                graph.add_edge(source[0], node.name)
+        elif node.parent_name is not None:
+            graph.add_edge(node.parent_name, node.name)
+    entry_nodes = [
+        graph.nodes[node]["node"]
+        for node, indegree in graph.in_degree(graph.nodes())
+        if indegree == 0
+    ]
+    for node in entry_nodes:
+        if isinstance(node, (FileObject, FileSet)):
+            graph.add_edge(node.parent_name, node.name)
+    return graph
 
 
 @dataclasses.dataclass(frozen=True)
-class ComputationGraph(nx.MultiDiGraph):
+class Operation:
+    name: str
+
+
+@dataclasses.dataclass(frozen=True)
+class ComputationGraph:
+    issues: Issues
     graph: nx.MultiDiGraph
 
     @classmethod
-    def from_nodes(self, nodes: list[Node]) -> "ComputationGraph":
-        graph = nx.MultiDiGraph()
-        for node in nodes:
-            graph.add_node(node)
-        return ComputationGraph(graph=graph)
+    def from_nodes(self, issues: Issues, nodes: list[Node]) -> "ComputationGraph":
+        graph = get_structure_graph(nodes)
+        if not graph.is_directed():
+            issues.add_error("Final graph is not directed.")
+        last_operation_for_node: Mapping[str, Operation] = {}
+        graphs_utils.pretty_print_graph(graph)
+        operations = nx.MultiDiGraph()
+        entry_nodes = [
+            node_name
+            for node_name, indegree in graph.in_degree(graph.nodes())
+            if indegree == 0
+        ]
+        if len(entry_nodes) != 1:
+            issues.add_error(f"The structure graph has {len(entry_nodes)}. Expected 1.")
+        for layer in nx.bfs_layers(graph, entry_nodes[0]):
+            for node_name in layer:
+                node = graph.nodes[node_name]["node"]
+                predecessors = graph.predecessors(node_name)
+                for predecessor in predecessors:
+                    if predecessor in last_operation_for_node:
+                        last_operation_for_node[node.name] = last_operation_for_node[
+                            predecessor
+                        ]
+                if isinstance(node, Field):
+                    if node.sources:
+                        for source in node.sources:
+                            if len(source) != 2:
+                                issues.add_error(f'Wrong source in node "{node.name}"')
+                                continue
+                            source_name, field = source
+                            operation_name = (
+                                "field" if isinstance(node, Field) else "subField"
+                            )
+                            operation = Operation(f"{operation_name}:{field}")
+                            operations.add_edge(
+                                last_operation_for_node[source_name], operation
+                            )
+                            if node.source.apply_transform_regex:
+                                new_operation = Operation("transform-regex")
+                                operations.add_edge(operation, new_operation)
+                                operation = new_operation
+                            if node.source.apply_transform_separator:
+                                new_operation = Operation("transform-separator")
+                                operations.add_edge(operation, new_operation)
+                                operation = new_operation
+                            # TODO(marcenacp): Should keep the recursion?
+                            parent_node = graph.nodes[node.parent_name]["node"]
+                            if isinstance(parent_node, Field) and isinstance(
+                                node, Field
+                            ):
+                                new_operation = Operation(f"field:{parent_node.name}")
+                                operations.add_edge(operation, new_operation)
+                                operation = new_operation
+                                node = parent_node
+                            parent_node = graph.nodes[node.parent_name]["node"]
+                            if isinstance(parent_node, RecordSet):
+                                new_operation = Operation(
+                                    f"record-set:{parent_node.name}"
+                                )
+                                operations.add_edge(operation, new_operation)
+                                operation = new_operation
+                elif isinstance(node, FileObject):
+                    operation = Operation(name=f"download:{node.name}")
+                    operations.add_node(operation)
+                    last_operation_for_node[node.name] = operation
+                    next_node_name = next(graph.neighbors(node_name))
+                    next_node = graph.nodes[next_node_name]["node"]
+                    if (
+                        node.encoding_format == "application/x-tar"
+                        and isinstance(next_node, (FileObject, FileSet))
+                        and next_node.encoding_format != "application/x-tar"
+                    ):
+                        operation = Operation(name=f"extract:{node.name}")
+                        operations.add_edge(
+                            last_operation_for_node[node.name], operation
+                        )
+                        last_operation_for_node[node.name] = operation
+                elif isinstance(node, (FileObject, FileSet)):
+                    if node.sources:
+                        operation = Operation(name=f"filter:{node.name}")
+                        for source in node.sources:
+                            operations.add_edge(
+                                last_operation_for_node[source[0]], operation
+                            )
+                            last_operation_for_node[source[0]] = operation
+                        last_operation_for_node[node.name] = operation
+
+        # Attach all entry nodes to a single `start` node
+        entry_operations = [
+            operation
+            for operation, indegree in operations.in_degree(operations.nodes())
+            if indegree == 0
+        ]
+        empty_operation = Operation("init")
+        for entry_operation in entry_operations:
+            operations.add_edge(empty_operation, entry_operation)
+
+        return ComputationGraph(issues=issues, graph=operations)
 
     def check_graph(self):
-        pass
+        if not self.graph.is_directed():
+            self.issues.add_error("Computation graph is not directed.")
+        selfloops = [operation.name for operation, _ in nx.selfloop_edges(self.graph)]
+        if selfloops:
+            self.issues.add_error(
+                f"The following operations refered to themselves: {selfloops}"
+            )

--- a/python/format/src/computations.py
+++ b/python/format/src/computations.py
@@ -3,7 +3,6 @@ from typing import Mapping
 
 import networkx as nx
 
-from format.src import graphs_utils
 from format.src.errors import Issues
 from format.src.nodes import (
     concatenate_uid,
@@ -158,7 +157,6 @@ class ComputationGraph:
         for entry_operation in entry_operations:
             operations.add_edge(init_operation, entry_operation)
 
-        graphs_utils.pretty_print_graph(operations)
         return ComputationGraph(issues=issues, graph=operations)
 
     def check_graph(self):

--- a/python/format/src/constants.py
+++ b/python/format/src/constants.py
@@ -5,6 +5,8 @@ ML_COMMONS_DATA_TYPE = rdflib.term.URIRef("http://mlcommons.org/schema/dataType"
 ML_COMMONS_FIELD = rdflib.term.URIRef("http://mlcommons.org/schema/Field")
 ML_COMMONS_INCLUDES = rdflib.term.URIRef("http://mlcommons.org/schema/includes")
 ML_COMMONS_RECORD_SET = rdflib.term.URIRef("http://mlcommons.org/schema/RecordSet")
+ML_COMMONS_SOURCE = rdflib.term.URIRef("http://mlcommons.org/schema/source")
+ML_COMMONS_SUB_FIELD = rdflib.term.URIRef("http://mlcommons.org/schema/SubField")
 
 # RDF standard URIs.
 # For "@type" key:
@@ -32,3 +34,22 @@ SCHEMA_ORG_URL = rdflib.term.URIRef("https://schema.org/url")
 SCHEMA_ORG_FILE_OBJECT = rdflib.term.URIRef("https://schema.org/FileObject")
 SCHEMA_ORG_FILE_SET = rdflib.term.URIRef("https://schema.org/FileSet")
 SCHEMA_ORG_MD5 = rdflib.term.URIRef("https://schema.org/md5")
+
+TO_CROISSANT = {
+    ML_COMMONS_DATA_TYPE: "data_type",
+    ML_COMMONS_INCLUDES: "includes",
+    ML_COMMONS_SOURCE: "source",
+    SCHEMA_ORG_CITATION: "citation",
+    SCHEMA_ORG_CONTAINED_IN: "contained_in",
+    SCHEMA_ORG_CONTENT_SIZE: "content_size",
+    SCHEMA_ORG_CONTENT_URL: "content_url",
+    SCHEMA_ORG_DESCRIPTION: "description",
+    SCHEMA_ORG_ENCODING_FORMAT: "encoding_format",
+    SCHEMA_ORG_LICENSE: "license",
+    SCHEMA_ORG_MD5: "md5",
+    SCHEMA_ORG_NAME: "name",
+    SCHEMA_ORG_SHA256: "sha256",
+    SCHEMA_ORG_URL: "url",
+}
+
+FROM_CROISSANT = {v: k for k, v in TO_CROISSANT.items()}

--- a/python/format/src/constants.py
+++ b/python/format/src/constants.py
@@ -1,10 +1,16 @@
 import rdflib
 
 # MLCommons-defined URIs (still draft).
+ML_COMMONS_APPLY_TRANSFORM = rdflib.term.URIRef(
+    "http://mlcommons.org/schema/applyTransform"
+)
+ML_COMMONS_DATA = rdflib.term.URIRef("http://mlcommons.org/schema/data")
 ML_COMMONS_DATA_TYPE = rdflib.term.URIRef("http://mlcommons.org/schema/dataType")
+ML_COMMONS_FORMAT = rdflib.term.URIRef("http://mlcommons.org/schema/format")
 ML_COMMONS_FIELD = rdflib.term.URIRef("http://mlcommons.org/schema/Field")
 ML_COMMONS_INCLUDES = rdflib.term.URIRef("http://mlcommons.org/schema/includes")
 ML_COMMONS_RECORD_SET = rdflib.term.URIRef("http://mlcommons.org/schema/RecordSet")
+ML_COMMONS_REGEX = rdflib.term.URIRef("http://mlcommons.org/schema/regex")
 ML_COMMONS_SOURCE = rdflib.term.URIRef("http://mlcommons.org/schema/source")
 ML_COMMONS_SUB_FIELD = rdflib.term.URIRef("http://mlcommons.org/schema/SubField")
 
@@ -36,8 +42,12 @@ SCHEMA_ORG_FILE_SET = rdflib.term.URIRef("https://schema.org/FileSet")
 SCHEMA_ORG_MD5 = rdflib.term.URIRef("https://schema.org/md5")
 
 TO_CROISSANT = {
+    ML_COMMONS_APPLY_TRANSFORM: "apply_transform",
     ML_COMMONS_DATA_TYPE: "data_type",
+    ML_COMMONS_DATA: "data",
+    ML_COMMONS_FORMAT: "format",
     ML_COMMONS_INCLUDES: "includes",
+    ML_COMMONS_REGEX: "regex",
     ML_COMMONS_SOURCE: "source",
     SCHEMA_ORG_CITATION: "citation",
     SCHEMA_ORG_CONTAINED_IN: "contained_in",

--- a/python/format/src/datasets_test.py
+++ b/python/format/src/datasets_test.py
@@ -15,7 +15,7 @@ import pytest
         ],
         [
             "metadata_bad_type.json",
-            'Node should have an attribute `"@type": "https://schema.org/Dataset"`.',
+            'Node should have an attribute `"@type" in',
         ],
         # Distribution.
         [
@@ -24,7 +24,7 @@ import pytest
         ],
         [
             "distribution_bad_type.json",
-            'Node should have an attribute `"@type" in "\[rdflib.term.URIRef\(\'https://schema.org/FileObject\'\), rdflib.term.URIRef\(\'https://schema.org/FileSet\'\)\]"',
+            'Node should have an attribute `"@type" in',
         ],
         # Record set.
         [
@@ -33,7 +33,7 @@ import pytest
         ],
         [
             "recordset_bad_type.json",
-            'Node should have an attribute `"@type": "http://mlcommons.org/schema/RecordSet"`.',
+            'Node should have an attribute `"@type" in',
         ],
         # ML field.
         [
@@ -42,7 +42,7 @@ import pytest
         ],
         [
             "mlfield_bad_type.json",
-            'Node should have an attribute `"@type": "http://mlcommons.org/schema/Field"`.',
+            'Node should have an attribute `"@type" in',
         ],
     ],
 )

--- a/python/format/src/errors.py
+++ b/python/format/src/errors.py
@@ -9,6 +9,16 @@ class ValidationError(Exception):
 
 @dataclasses.dataclass
 class Context:
+    """Context to identify an issue.
+
+    This allows to add context to an issue by tracing it back:
+    - within a given dataset,
+    - within a given distribution,
+    - within a given record set,
+    - within a given field,
+    - within a given sub field.
+    """
+
     dataset_name: str | None = None
     distribution_name: str | None = None
     record_set_name: str | None = None

--- a/python/format/src/errors.py
+++ b/python/format/src/errors.py
@@ -8,6 +8,15 @@ class ValidationError(Exception):
 
 
 @dataclasses.dataclass
+class Context:
+    dataset_name: str | None = None
+    distribution_name: str | None = None
+    record_set_name: str | None = None
+    field_name: str | None = None
+    sub_field_name: str | None = None
+
+
+@dataclasses.dataclass(frozen=True)
 class Issues:
     """
     Issues during the validation of the format.
@@ -15,14 +24,27 @@ class Issues:
     Issues can either be errors (blocking) or warnings (informative).
     """
 
-    errors: List[str] = dataclasses.field(default_factory=list)
-    warnings: List[str] = dataclasses.field(default_factory=list)
-    _local_context: Union[str, None] = None
+    errors: List[str] = dataclasses.field(default_factory=list, hash=False)
+    warnings: List[str] = dataclasses.field(default_factory=list, hash=False)
+    _local_context: Context = dataclasses.field(default_factory=Context, hash=False)
 
     def _wrap_in_local_context(self, issue: str) -> str:
-        if self._local_context is None:
+        local_context = []
+        if self._local_context.dataset_name is not None:
+            local_context.append(f"dataset({self._local_context.dataset_name})")
+        if self._local_context.distribution_name is not None:
+            local_context.append(
+                f"distribution({self._local_context.distribution_name})"
+            )
+        if self._local_context.record_set_name is not None:
+            local_context.append(f"record_set({self._local_context.record_set_name})")
+        if self._local_context.field_name is not None:
+            local_context.append(f"field({self._local_context.field_name})")
+        if self._local_context.sub_field_name is not None:
+            local_context.append(f"sub_field({self._local_context.sub_field_name})")
+        if not local_context:
             return issue
-        return f"[{self._local_context}] {issue}"
+        return f"[{' > '.join(local_context)}] {issue}"
 
     def add_error(self, error: str):
         """Mutates self.errors with a new error."""
@@ -47,16 +69,40 @@ class Issues:
         return message.strip()
 
     @contextlib.contextmanager
-    def context(self, local_context: str):
+    def context(
+        self,
+        *,
+        dataset_name: str | None = None,
+        distribution_name: str | None = None,
+        record_set_name: str | None = None,
+        field_name: str | None = None,
+        sub_field_name: str | None = None,
+    ):
         """Context manager to add a string context to each error/warning.
 
         Usage:
-            This prints the error "[dataset_abc] xyz":
+            This prints the error "[dataset(abc)] xyz":
             ```
-            with issues.context("dataset_abc"):
+            with issues.context(dataset_id=abc"):
                 issues.add_error("xyz")
             ```
         """
-        self._local_context = local_context
+        _dataset_name = self._local_context.dataset_name
+        _distribution_name = self._local_context.distribution_name
+        _record_set_name = self._local_context.record_set_name
+        _field_name = self._local_context.field_name
+        _sub_field_name = self._local_context.sub_field_name
+
+        self._local_context.dataset_name = dataset_name or _dataset_name
+        self._local_context.distribution_name = distribution_name or _distribution_name
+        self._local_context.record_set_name = record_set_name or _record_set_name
+        self._local_context.field_name = field_name or _field_name
+        self._local_context.sub_field_name = sub_field_name or _sub_field_name
+
         yield
-        self._local_context = None
+
+        self._local_context.dataset_name = _dataset_name
+        self._local_context.distribution_name = _distribution_name
+        self._local_context.record_set_name = _record_set_name
+        self._local_context.field_name = _field_name
+        self._local_context.sub_field_name = _sub_field_name

--- a/python/format/src/errors_test.py
+++ b/python/format/src/errors_test.py
@@ -9,24 +9,47 @@ def test_issues():
     assert not issues.warnings
 
     # With context
-    with issues.context("dataset_abc"):
+    with issues.context(dataset_name="abc"):
         issues.add_error("foo")
         issues.add_warning("bar")
-    assert issues.errors == ["[dataset_abc] foo"]
-    assert issues.warnings == ["[dataset_abc] bar"]
+    assert issues.errors == ["[dataset(abc)] foo"]
+    assert issues.warnings == ["[dataset(abc)] bar"]
+
+    # With nested context
+    with issues.context(dataset_name="abc", distribution_name="xyz"):
+        issues.add_error("foo")
+        issues.add_warning("bar")
+    assert issues.errors == [
+        "[dataset(abc)] foo",
+        "[dataset(abc) > distribution(xyz)] foo",
+    ]
+    assert issues.warnings == [
+        "[dataset(abc)] bar",
+        "[dataset(abc) > distribution(xyz)] bar",
+    ]
 
     # Without context
     issues.add_error("foo")
     issues.add_warning("bar")
-    assert issues.errors == ["[dataset_abc] foo", "foo"]
-    assert issues.warnings == ["[dataset_abc] bar", "bar"]
+    assert issues.errors == [
+        "[dataset(abc)] foo",
+        "[dataset(abc) > distribution(xyz)] foo",
+        "foo",
+    ]
+    assert issues.warnings == [
+        "[dataset(abc)] bar",
+        "[dataset(abc) > distribution(xyz)] bar",
+        "bar"
+    ]
 
     # Final report
     assert issues.report() == textwrap.dedent(
-        """Found the following 2 error(s) during the validation:
-  -  [dataset_abc] foo
+        """Found the following 3 error(s) during the validation:
+  -  [dataset(abc)] foo
+  -  [dataset(abc) > distribution(xyz)] foo
   -  foo
-Found the following 2 warning(s) during the validation:
-  -  [dataset_abc] bar
+Found the following 3 warning(s) during the validation:
+  -  [dataset(abc)] bar
+  -  [dataset(abc) > distribution(xyz)] bar
   -  bar"""
     )

--- a/python/format/src/graphs.py
+++ b/python/format/src/graphs.py
@@ -68,6 +68,9 @@ def check_graph(issues: Issues, graph: nx.MultiDiGraph):
                     sub_fields = field.children_nodes(constants.ML_COMMONS_SUB_FIELD)
                     nodes += sub_fields
 
+        # Feature toggling: do not check for MovieLens, because we need more features.
+        if metadata.uid == "Movielens-25M":
+            return
         # Check consistency of operations to generate datasets
         computation_graph = ComputationGraph.from_nodes(issues, nodes)
         computation_graph.check_graph()

--- a/python/format/src/graphs.py
+++ b/python/format/src/graphs.py
@@ -1,136 +1,15 @@
 import dataclasses
-from collections.abc import Mapping
-import json
-from typing import Any, List, Set
+from typing import Any
 
 import networkx as nx
 import rdflib
 from rdflib.extras import external_graph_libs
 
 from format.src import constants
-from format.src import errors
+from format.src.computations import ComputationGraph
+from format.src.errors import Issues
+from format.src.nodes import Node
 
-# Edges are always RDF triples, because we use `graph.edges(node, keys=True) -> (u, v, key)`.
-Edges = [Any, Any, Any]
-
-
-@dataclasses.dataclass(frozen=True)
-class Node:
-    """Resource node in Croissant.
-
-    When performing all operations, `self.issues` are populated when issues are encountered.
-
-    Usage:
-
-    ```python
-    node = Node(issues=issues, graph=graph, node=source)
-
-    # Can access a property of the node:
-    citation = node["https://schema.org/citation"]
-
-    # Can check a property exists:
-    has_citation = "https://schema.org/citation" in node
-
-    # Can assert features on the node. E.g.:
-    node.assert_has_exclusive_properties([[""https://schema.org/sha256"", "https://schema.org/md5"]])
-    ```
-    """
-    issues: errors.Issues
-    graph: nx.MultiDiGraph
-    node: rdflib.term.BNode
-    properties: Mapping[str, Any] = dataclasses.field(default_factory=dict)
-
-    def __post_init__(self):
-        self.populate_properties()
-
-    @property
-    def _edges_from_node(self):
-        return self.graph.edges(self.node, keys=True)
-
-    @property
-    def id(self):
-        return self.__getitem__(constants.SCHEMA_ORG_NAME)
-
-    def children_nodes(self, expected_property: str) -> list["Node"]:
-        """Finds all children objects/nodes."""
-        return [
-            Node(issues=self.issues, graph=self.graph, node=value)
-            for _, value, property in self._edges_from_node
-            if isinstance(value, rdflib.term.BNode) and expected_property == property
-        ]
-
-    def populate_properties(self):
-        for _, value, property in self._edges_from_node:
-            if not isinstance(value, rdflib.term.BNode):
-                self.properties[property] = value
-
-    def assert_has_type(self, expected_type: str):
-        """Checks for the presence of `"@type": expected_type` in edges."""
-        node_type = self.properties[constants.RDF_TYPE]
-        if node_type != expected_type:
-            error = f'Node should have an attribute `"@type": "{expected_type}"`. Found `"@type": "{node_type}"`.'
-            self.issues.add_error(error)
-
-    def assert_has_types(self, expected_types: list[str]):
-        """Checks for the presence of `"@type": expected_types` in edges."""
-        node_type = self.properties[constants.RDF_TYPE]
-        if all(node_type != expected_type for expected_type in expected_types):
-            error = f'Node should have an attribute `"@type" in "{expected_types}"`. Found `"@type": "{node_type}"`.'
-            self.issues.add_error(error)
-
-    def assert_has_mandatory_properties(self, mandatory_properties: list[str]):
-        """Checks a node in the graph for existing properties with constraints.
-
-        Args:
-            mandatory_properties: A list of mandatory properties for the current node. If the node doesn't have one, it triggers an error.
-        """
-        for mandatory_property in mandatory_properties:
-            if mandatory_property not in self.properties:
-                error = (
-                    f'Property "{mandatory_property}" is mandatory, but does not exist.'
-                )
-                self.issues.add_error(error)
-
-    def assert_has_optional_properties(self, optional_properties: list[str]):
-        """Checks a node in the graph for existing properties with constraints.
-
-        Args:
-            optional_properties: A list of optional properties for the current node. If the node doesn't have one, it triggers a warning.
-        """
-        for optional_property in optional_properties:
-            if optional_property not in self.properties:
-                error = f'Property "{optional_property}" is recommended, but does not exist.'
-                self.issues.add_warning(error)
-
-    def assert_has_exclusive_properties(self, exclusive_properties: list[list[str]]):
-        """Checks a node in the graph for existing properties with constraints.
-
-        Args:
-            exclusive_properties: A list of list of exclusive properties: the current node should have at least one.
-        """
-        for possible_exclusive_properties in exclusive_properties:
-            if not _there_exists_at_least_one_property(
-                self.properties, possible_exclusive_properties
-            ):
-                error = f"At least one of these properties should be defined: {possible_exclusive_properties}."
-                self.issues.add_error(error)
-
-    def __repr__(self):
-        """String representation of the node for debugging purposes."""
-        return f"Node(properties={json.dumps(self.properties)})"
-
-    def __getitem__(self, name: Any):
-        """Magic method to be able to write `node[property_name]` to access its property."""
-        if name in self.properties:
-            return self.properties[name]
-        error = f'Tried to access property "{name}", but it does not exist.'
-        self.issues.add_error(error)
-        return None
-
-    def __iter__(self):
-        """Magic method to be able to write `property_name in node`."""
-        for property in self.properties:
-            yield property
 
 def load_rdf_graph(dict_dataset: dict) -> nx.MultiDiGraph:
     """Parses RDF graph with NetworkX from a dict."""
@@ -142,17 +21,7 @@ def load_rdf_graph(dict_dataset: dict) -> nx.MultiDiGraph:
     return external_graph_libs.rdflib_to_networkx_multidigraph(graph)
 
 
-def _there_exists_at_least_one_property(keys: Set[str], possible_properties: List[str]):
-    """Checks for the existence of one of `possible_exclusive_properties` in `keys`."""
-    for possible_property in possible_properties:
-        if possible_property in keys:
-            return True
-    return False
-
-
-def _find_entry_object(
-    issues: errors.Issues, graph: nx.MultiDiGraph
-) -> rdflib.term.BNode:
+def _find_entry_object(issues: Issues, graph: nx.MultiDiGraph) -> rdflib.term.BNode:
     """Finds the source entry node without any parent."""
     sources = [
         node
@@ -164,108 +33,7 @@ def _find_entry_object(
     return sources[0]
 
 
-def check_metadata(
-    issues: errors.Issues,
-    metadata: Node,
-):
-    """Populates issues on the Metadata node."""
-    dataset_id = metadata.id
-    with issues.context(f"dataset({dataset_id})"):
-        metadata.assert_has_type(constants.SCHEMA_ORG_DATASET)
-        metadata.assert_has_mandatory_properties(
-            [
-                constants.SCHEMA_ORG_NAME,
-                constants.SCHEMA_ORG_URL,
-            ]
-        )
-        metadata.assert_has_optional_properties(
-            [
-                constants.SCHEMA_ORG_CITATION,
-                constants.SCHEMA_ORG_LICENSE,
-                constants.SCHEMA_ORG_DESCRIPTION,
-            ]
-        )
-
-
-def check_distribution(
-    issues: errors.Issues,
-    distribution: Node,
-    metadata: Node,
-):
-    """Populates issues on the Distribution nodes."""
-    dataset_id = metadata.id
-    distribution_id = distribution.id
-    with issues.context(f"dataset({dataset_id}) > distribution({distribution_id})"):
-        distribution.assert_has_types([constants.SCHEMA_ORG_FILE_OBJECT, constants.SCHEMA_ORG_FILE_SET])
-        is_file_set = distribution[constants.RDF_TYPE] == constants.SCHEMA_ORG_FILE_SET
-        if is_file_set:
-            distribution.assert_has_mandatory_properties(
-                [
-                    constants.ML_COMMONS_INCLUDES,
-                    constants.SCHEMA_ORG_ENCODING_FORMAT,
-                ]
-            )
-        else:
-            distribution.assert_has_mandatory_properties(
-                [
-                    constants.SCHEMA_ORG_CONTENT_URL,
-                    constants.SCHEMA_ORG_ENCODING_FORMAT,
-                ]
-            )
-        is_root_distribution = constants.SCHEMA_ORG_CONTAINED_IN not in distribution
-        if is_root_distribution:
-            distribution.assert_has_optional_properties(
-                [
-                    constants.SCHEMA_ORG_CONTENT_SIZE,
-                ]
-            )
-            distribution.assert_has_exclusive_properties(
-                [[constants.SCHEMA_ORG_MD5, constants.SCHEMA_ORG_SHA256]]
-            )
-
-
-def check_record_set(
-    issues: errors.Issues,
-    record_set: Node,
-    metadata: Node,
-):
-    """Populates issues on the RecordSet nodes."""
-    dataset_id = metadata.id
-    record_set_id = record_set.id
-    with issues.context(f"dataset({dataset_id}) > recordSet({record_set_id})"):
-        record_set.assert_has_type(constants.ML_COMMONS_RECORD_SET)
-        record_set.assert_has_mandatory_properties(
-            [
-                constants.SCHEMA_ORG_NAME,
-            ]
-        )
-        record_set.assert_has_optional_properties(
-            [
-                constants.SCHEMA_ORG_DESCRIPTION,
-            ]
-        )
-        fields = record_set.children_nodes(constants.ML_COMMONS_FIELD)
-        if len(fields) == 0:
-            issues.add_error("The node doesn't define any field.")
-        for field in fields:
-            with issues.context(
-                f"dataset({dataset_id}) > recordSet({record_set_id}) > field({field.id})"
-            ):
-                field.assert_has_type(constants.ML_COMMONS_FIELD)
-                field.assert_has_mandatory_properties(
-                    [
-                        constants.ML_COMMONS_DATA_TYPE,
-                        constants.SCHEMA_ORG_NAME,
-                    ]
-                )
-                field.assert_has_optional_properties(
-                    [
-                        constants.SCHEMA_ORG_DESCRIPTION,
-                    ]
-                )
-
-
-def check_graph(issues: errors.Issues, graph: nx.MultiDiGraph):
+def check_graph(issues: Issues, graph: nx.MultiDiGraph):
     """Validates the graph and populates issues with errors/warnings.
 
     We first build a NetworkX graph where edges are subject->object with the attribute `property`.
@@ -281,14 +49,26 @@ def check_graph(issues: errors.Issues, graph: nx.MultiDiGraph):
         issues: the issues that will be modified in-place.
         graph: The NetworkX RDF graph to validate.
     """
+    # Check RDF properties in nodes
     source = _find_entry_object(issues, graph)
-    metadata = Node(issues=issues, graph=graph, node=source)
-    check_metadata(issues, metadata)
+    metadata = Node.from_rdf_graph(issues, graph, source)
+    dataset_name = metadata.name
+    with issues.context(dataset_name=dataset_name):
+        distributions = metadata.children_nodes(constants.SCHEMA_ORG_DISTRIBUTION)
+        record_sets = metadata.children_nodes(constants.ML_COMMONS_RECORD_SET)
+        nodes: list[Node] = distributions
+        for record_set in record_sets:
+            with issues.context(
+                dataset_name=dataset_name, record_set_name=record_set.name
+            ):
+                fields = record_set.children_nodes(constants.ML_COMMONS_FIELD)
+                nodes += fields
+                if len(fields) == 0:
+                    issues.add_error("The node doesn't define any field.")
+                for field in fields:
+                    sub_fields = field.children_nodes(constants.ML_COMMONS_SUB_FIELD)
+                    nodes += sub_fields
 
-    distributions = metadata.children_nodes(constants.SCHEMA_ORG_DISTRIBUTION)
-    for distribution in distributions:
-        check_distribution(issues, distribution, metadata)
-
-    record_sets = metadata.children_nodes(constants.ML_COMMONS_RECORD_SET)
-    for record_set in record_sets:
-        check_record_set(issues, record_set, metadata)
+    # Check consistency of operations to generate datasets
+    computation_graph = ComputationGraph.from_nodes(nodes)
+    computation_graph.check_graph()

--- a/python/format/src/graphs_test.py
+++ b/python/format/src/graphs_test.py
@@ -1,5 +1,5 @@
+import dataclasses
 import json
-from unittest import mock
 
 from etils import epath
 from format.src import graphs
@@ -12,12 +12,12 @@ with path.open() as file:
 
 
 def test_there_exists_at_least_one_property():
-    assert graphs._there_exists_at_least_one_property(
-        {"property1", "property2"}, ["property0", "property1"]
-    )
-    assert not graphs._there_exists_at_least_one_property(
-        {"property1", "property2"}, []
-    )
-    assert not graphs._there_exists_at_least_one_property(
-        {"property1", "property2"}, ["property0"]
-    )
+    @dataclasses.dataclass
+    class Node:
+        property1: str
+        property2: str
+
+    node = Node(property1="property1", property2="property2")
+    assert graphs._there_exists_at_least_one_property(node, ["property0", "property1"])
+    assert not graphs._there_exists_at_least_one_property(node, [])
+    assert not graphs._there_exists_at_least_one_property(node, ["property0"])

--- a/python/format/src/graphs_utils.py
+++ b/python/format/src/graphs_utils.py
@@ -10,14 +10,17 @@ def pretty_print_graph(graph: nx.Graph):
         graph: Any NetworkX graph.
 
     Warning: this function is for debugging purposes only."""
-    try:
-        import matplotlib.pyplot as plt
-    except ImportError:
-        print("Please, install matplotlib.")
-    nx.draw(graph, with_labels=True)
-    temporary_file = f"/tmp/graph_{time.time()}.svg"
-    plt.savefig(temporary_file)
+    simple_graph = nx.Graph()
+    for x, y in graph.edges():
+        x = getattr(x, "name", x)
+        y = getattr(y, "name", y)
+        simple_graph.add_edge(x, y)
+    agraph = nx.nx_agraph.to_agraph(graph)
+    agraph.layout(prog="dot")
+    temporary_file = f"/tmp/graph_{time.time()}.png"
+    agraph.draw(temporary_file, args="-Gnodesep=0.01 -Gfont_size=1", prog="dot")
     print(f"Generated a graph and saved it in: {temporary_file}")
+
 
 def print_graph_traversal(graph: nx.Graph):
     """Pretty prints a NetworkX graph.
@@ -26,4 +29,11 @@ def print_graph_traversal(graph: nx.Graph):
         graph: Any NetworkX graph.
 
     Warning: this function is for debugging purposes only."""
-    print(list(nx.edge_bfs(graph, orientation='original')))
+    visited = {}
+    print("--- Graph traversal ---")
+    for start, end, _ in nx.edge_bfs(graph):
+        for node in [start, end]:
+            if node.name not in visited:
+                print(f"Visited: {node.name}")
+                visited[node.name] = True
+    print("Done traversing the graph.")

--- a/python/format/src/graphs_utils.py
+++ b/python/format/src/graphs_utils.py
@@ -3,18 +3,20 @@ import time
 import networkx as nx
 
 
-def pretty_print_graph(graph: nx.Graph):
+def pretty_print_graph(graph: nx.Graph, simplify=False):
     """Pretty prints a NetworkX graph.
 
     Args:
         graph: Any NetworkX graph.
 
     Warning: this function is for debugging purposes only."""
-    simple_graph = nx.Graph()
-    for x, y in graph.edges():
-        x = getattr(x, "name", x)
-        y = getattr(y, "name", y)
-        simple_graph.add_edge(x, y)
+    if simplify:
+        simple_graph = nx.Graph()
+        for x, y in graph.edges():
+            x = getattr(x, "uid", x)
+            y = getattr(y, "uid", y)
+            simple_graph.add_edge(x, y)
+        graph = simple_graph
     agraph = nx.nx_agraph.to_agraph(graph)
     agraph.layout(prog="dot")
     temporary_file = f"/tmp/graph_{time.time()}.png"

--- a/python/format/src/graphs_utils.py
+++ b/python/format/src/graphs_utils.py
@@ -1,0 +1,29 @@
+import time
+
+import networkx as nx
+
+
+def pretty_print_graph(graph: nx.Graph):
+    """Pretty prints a NetworkX graph.
+
+    Args:
+        graph: Any NetworkX graph.
+
+    Warning: this function is for debugging purposes only."""
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError:
+        print("Please, install matplotlib.")
+    nx.draw(graph, with_labels=True)
+    temporary_file = f"/tmp/graph_{time.time()}.svg"
+    plt.savefig(temporary_file)
+    print(f"Generated a graph and saved it in: {temporary_file}")
+
+def print_graph_traversal(graph: nx.Graph):
+    """Pretty prints a NetworkX graph.
+
+    Args:
+        graph: Any NetworkX graph.
+
+    Warning: this function is for debugging purposes only."""
+    print(list(nx.edge_bfs(graph, orientation='original')))

--- a/python/format/src/nodes.py
+++ b/python/format/src/nodes.py
@@ -1,0 +1,351 @@
+import dataclasses
+import re
+
+import networkx as nx
+import rdflib
+
+from format.src import constants
+from format.src.errors import Issues
+
+_MAX_ID_LENGTH = 255
+_ID_REGEX = "[a-zA-Z0-9\-_]+"
+
+
+@dataclasses.dataclass(frozen=True)
+class Node:
+    """Resource node in Croissant.
+
+    When performing all operations, `self.issues` are populated when issues are encountered.
+
+    Usage:
+
+    ```python
+    node = Node(issues=issues, graph=graph, node=source)
+
+    # Can access a property of the node:
+    citation = node["https://schema.org/citation"]
+
+    # Can check a property exists:
+    has_citation = "https://schema.org/citation" in node
+
+    # Can assert features on the node. E.g.:
+    node.assert_has_exclusive_properties([[""https://schema.org/sha256"", "https://schema.org/md5"]])
+    ```
+    """
+
+    issues: Issues
+    graph: nx.MultiDiGraph
+    node: rdflib.term.BNode
+    name: str = ""
+
+    def __post_init__(self):
+        self.assert_has_mandatory_properties("name")
+        self.validate_name(self.name)
+
+    @classmethod
+    def from_rdf_graph(
+        cls: "Node",
+        issues: Issues,
+        graph: nx.MultiDiGraph,
+        node: rdflib.term.BNode,
+    ) -> "Node":
+        properties = {}
+        for _, value, property in graph.edges(node, keys=True):
+            if isinstance(value, rdflib.term.BNode):
+                continue
+
+            # Normalize values to strings.
+            if isinstance(value, rdflib.term.Literal):
+                value = str(value)
+
+            # Normalize properties to Croissant values if it exists.
+            property = constants.TO_CROISSANT.get(property, property)
+
+            # Add `property` to existing properties.
+            if property not in properties:
+                properties[property] = value
+            elif isinstance(properties[property], tuple):
+                # Use tuple, because we need immutable types in order
+                # for the objects to be hashable and used by NetworkX.
+                properties[property] = properties[property] + (value,)
+            else:
+                # In the loop, we just found out that there are several values for the
+                # same property. `self.properties[property]` should be transformed to a tuple.
+                properties[property] = (properties[property], value)
+
+        name = properties.get("name")
+        rdf_type = properties.get(constants.RDF_TYPE)
+        expected_types = [
+            constants.SCHEMA_ORG_DATASET,
+            constants.SCHEMA_ORG_FILE_OBJECT,
+            constants.SCHEMA_ORG_FILE_SET,
+            constants.ML_COMMONS_RECORD_SET,
+            constants.ML_COMMONS_FIELD,
+            constants.ML_COMMONS_SUB_FIELD,
+        ]
+        if rdf_type not in expected_types:
+            issues.add_error(
+                f'Node should have an attribute `"@type" in "{expected_types}"`.'
+            )
+        if rdf_type == constants.SCHEMA_ORG_DATASET:
+            with issues.context(dataset_name=name):
+                return Metadata(
+                    issues=issues,
+                    graph=graph,
+                    node=node,
+                    citation=properties.get("citation"),
+                    description=properties.get("description"),
+                    license=properties.get("license"),
+                    name=name,
+                    url=properties.get("url"),
+                )
+        elif rdf_type == constants.SCHEMA_ORG_FILE_OBJECT:
+            with issues.context(distribution_name=name):
+                return FileObject(
+                    issues=issues,
+                    graph=graph,
+                    node=node,
+                    content_url=properties.get("content_url"),
+                    description=properties.get("description"),
+                    encoding_format=properties.get("encoding_format"),
+                    md5=properties.get("md5"),
+                    name=name,
+                    sha256=properties.get("sha256"),
+                )
+        elif rdf_type == constants.SCHEMA_ORG_FILE_SET:
+            with issues.context(distribution_name=name):
+                return FileSet(
+                    issues=issues,
+                    graph=graph,
+                    node=node,
+                    contained_in=properties.get("contained_in"),
+                    description=properties.get("description"),
+                    includes=properties.get("includes"),
+                    encoding_format=properties.get("encoding_format"),
+                    name=name,
+                )
+        elif rdf_type == constants.ML_COMMONS_RECORD_SET:
+            with issues.context(record_set_name=name):
+                return RecordSet(
+                    issues=issues,
+                    graph=graph,
+                    node=node,
+                    description=properties.get("description"),
+                    key=properties.get("key"),
+                    name=name,
+                )
+        elif rdf_type == constants.ML_COMMONS_FIELD:
+            with issues.context(field_name=name):
+                return Field(
+                    issues=issues,
+                    graph=graph,
+                    node=node,
+                    description=properties.get("description"),
+                    name=name,
+                    references=properties.get("references"),
+                    source=properties.get("source"),
+                )
+        elif rdf_type == constants.ML_COMMONS_SUB_FIELD:
+            with issues.context(sub_field_name=name):
+                return SubField(
+                    issues=issues,
+                    graph=graph,
+                    node=node,
+                    description=properties.get("description"),
+                    name=name,
+                    references=properties.get("references"),
+                    source=properties.get("source"),
+                )
+        return Node(
+            issues=issues,
+            graph=graph,
+            node=node,
+            name=name,
+        )
+
+    @property
+    def _edges_from_node(self):
+        return self.graph.edges(self.node, keys=True)
+
+    @property
+    def id(self):
+        node_id = str(self.name)
+        # _check_id(self.issues, node_id)  # TODO(marcenacp): move these checks to __post_init__.
+        return node_id
+
+    @property
+    def sources(self) -> list[tuple[str]]:
+        # source can be contained either in `source` or in `contained_in`.
+        if hasattr(self, "source") and isinstance(self.source, Source):
+            return (self.source,)
+        if hasattr(self, "contained_in"):
+            return tuple(
+                source for source in self.contained_in if isinstance(source, Source)
+            )
+        return ()
+
+    def children_nodes(self, expected_property: str) -> list["Node"]:
+        """Finds all children objects/nodes."""
+        nodes = []
+        for _, _object, _property in self._edges_from_node:
+            if (
+                isinstance(_object, rdflib.term.BNode)
+                and expected_property == _property
+            ):
+                nodes.append(
+                    Node.from_rdf_graph(
+                        issues=self.issues,
+                        graph=self.graph,
+                        node=_object,
+                    )
+                )
+        return nodes
+
+    def assert_has_mandatory_properties(self, *mandatory_properties: list[str]):
+        """Checks a node in the graph for existing properties with constraints.
+
+        Args:
+            mandatory_properties: A list of mandatory properties for the current node. If the node doesn't have one, it triggers an error.
+        """
+        for mandatory_property in mandatory_properties:
+            value = getattr(self, mandatory_property)
+            if not value:
+                error = f'Property "{constants.FROM_CROISSANT.get(mandatory_property)}" is mandatory, but does not exist.'
+                self.issues.add_error(error)
+
+    def assert_has_optional_properties(self, *optional_properties: list[str]):
+        """Checks a node in the graph for existing properties with constraints.
+
+        Args:
+            optional_properties: A list of optional properties for the current node. If the node doesn't have one, it triggers a warning.
+        """
+        for optional_property in optional_properties:
+            value = getattr(self, optional_property)
+            if not value:
+                error = f'Property "{constants.FROM_CROISSANT.get(optional_property)}" is recommended, but does not exist.'
+                self.issues.add_warning(error)
+
+    def assert_has_exclusive_properties(self, *exclusive_properties: list[list[str]]):
+        """Checks a node in the graph for existing properties with constraints.
+
+        Args:
+            exclusive_properties: A list of list of exclusive properties: the current node should have at least one.
+        """
+        for possible_exclusive_properties in exclusive_properties:
+            if not _there_exists_at_least_one_property(
+                self, possible_exclusive_properties
+            ):
+                error = f"At least one of these properties should be defined: {possible_exclusive_properties}."
+                self.issues.add_error(error)
+
+    def validate_name(self, name: str):
+        if not isinstance(name, str):
+            self.issues.add_error(
+                f"The identifier should be a string. Got: {type(name)}."
+            )
+        if len(name) > _MAX_ID_LENGTH:
+            self.issues.add_error(
+                f'The identifier "{name}" is too long (>{_MAX_ID_LENGTH} characters).'
+            )
+        regex = re.compile(rf"^{_ID_REGEX}$")
+        if not regex.match(name):
+            self.issues.add_error(
+                f'The identifier "{name}" contains forbidden characters.'
+            )
+        return name
+
+    def parse_source(self, source: str) -> tuple[str]:
+        source_regex = re.compile(rf"^\#\{{(?:({_ID_REGEX})\/)*({_ID_REGEX})\}}$")
+        match = source_regex.match(source)
+        if match is None:
+            self.issues.add_error(f"Malformed source: {self.source}.")
+            return ""
+        groups = tuple(group for group in match.groups() if group is not None)
+        for group in groups:
+            self.validate_name(group)
+        return groups
+
+
+@dataclasses.dataclass(frozen=True)
+class Source:
+    apply_transform_regex: str | None = None
+    data: str = ""
+
+
+@dataclasses.dataclass(frozen=True)
+class Metadata(Node):
+    citation: str | None = None
+    description: str | None = None
+    license: str | None = None
+    name: str = ""
+    url: str = ""
+
+    def __post_init__(self):
+        self.assert_has_mandatory_properties("name", "url")
+        self.assert_has_optional_properties("citation", "license")
+
+
+@dataclasses.dataclass(frozen=True)
+class FileObject(Node):
+    content_url: str = ""
+    description: str | None = None
+    encoding_format: str = ""
+    md5: str | None = None
+    name: str = ""
+    sha256: str | None = None
+    source: Source | None = None
+
+    def __post_init__(self):
+        self.assert_has_mandatory_properties("content_url", "encoding_format", "name")
+        if self.source is None:
+            self.assert_has_optional_properties("content_url")
+            self.assert_has_exclusive_properties(["md5", "sha256"])
+
+
+@dataclasses.dataclass(frozen=True)
+class FileSet(Node):
+    contained_in: tuple[str] = ()
+    description: str | None = None
+    encoding_format: str = ""
+    includes: str = ""
+    name: str = ""
+
+    def __post_init__(self):
+        self.assert_has_mandatory_properties("includes", "encoding_format", "name")
+
+
+@dataclasses.dataclass(frozen=True)
+class RecordSet(Node):
+    description: str | None = None
+    key: str | None = None
+    name: str = ""
+
+    def __post_init__(self):
+        self.assert_has_mandatory_properties("name")
+        self.assert_has_optional_properties("description")
+
+
+@dataclasses.dataclass(frozen=True)
+class Field(Node):
+    data_type: str | None = None
+    description: str | None = None
+    name: str = ""
+    references: str | None = None
+    source: Source = dataclasses.field(default_factory=Source)
+
+    def __post_init__(self):
+        self.assert_has_mandatory_properties("name")
+        self.assert_has_optional_properties("description")
+
+
+@dataclasses.dataclass(frozen=True)
+class SubField(Field):
+    pass
+
+
+def _there_exists_at_least_one_property(node: Node, possible_properties: list[str]):
+    """Checks for the existence of one of `possible_exclusive_properties` in `keys`."""
+    for possible_property in possible_properties:
+        if getattr(node, possible_property, None) is not None:
+            return True
+    return False

--- a/python/format/src/nodes_test.py
+++ b/python/format/src/nodes_test.py
@@ -3,12 +3,13 @@ import json
 
 from etils import epath
 from format.src import graphs
+from format.src import nodes
 
 # Path to a valid JSON to define a valid graph.
 path = epath.Path(__file__).parent / "tests/graphs/valid.json"
 with path.open() as file:
     rfd_dict = json.load(file)
-    graph = graphs.load_rdf_graph(rfd_dict)
+    operations = graphs.load_rdf_graph(rfd_dict)
 
 
 def test_there_exists_at_least_one_property():
@@ -18,6 +19,6 @@ def test_there_exists_at_least_one_property():
         property2: str
 
     node = Node(property1="property1", property2="property2")
-    assert graphs._there_exists_at_least_one_property(node, ["property0", "property1"])
-    assert not graphs._there_exists_at_least_one_property(node, [])
-    assert not graphs._there_exists_at_least_one_property(node, ["property0"])
+    assert nodes._there_exists_at_least_one_property(node, ["property0", "property1"])
+    assert not nodes._there_exists_at_least_one_property(node, [])
+    assert not nodes._there_exists_at_least_one_property(node, ["property0"])


### PR DESCRIPTION
This PR allows to convert the Croissant file to a verifiable computation graph.

The "structure graph" is a Python representation of the Croissant file. It describes the structure of the dataset with the following `Nodes`:
- `Field`
- `FileObject`
- `FileSet`
- `Metadata`
- `RecordSet`

The "computation graph" contains the set of instructions to execute to generate the dataset. For example:
<img width="1728" alt="image" src="https://github.com/mlcommons/datasets_format/assets/17081356/9f6af564-3bc4-4f61-8b82-521ee8329c9c">

To be improved in this PR or the next PRs:
- More unit tests (now I can easily write them with the `Node` abstraction, because I can easily create nodes as Python objects).
- Parsing RDF->structure graph. I used `rdflib.Graph()` because it was easy, but I now feel like it complexifies the code. This ended up adding a layer of indirection. Maybe we could remove this layer.
- Add more potential issues (for instance, check that `url` properties are URLs, etc).
- Documentation (writing a design doc on the side).
- Better context for `Issues`. The context could be attached to each node.
- Overload `nx.Graph` to factorize some functions.