### PR TITLE
Fix context in unit tests

### DIFF
--- a/python/format/src/tests/graphs/distribution_bad_type.json
+++ b/python/format/src/tests/graphs/distribution_bad_type.json
@@ -3,14 +3,17 @@
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
     "ml": "http://mlcommons.org/schema/",
-    "dataType": {
-      "@id": "ml:dataType",
-      "@type": "@id"
-    },
-    "recordSet": {
-      "@id": "ml:RecordSet",
-      "@type": "@id"
-    }
+    "includes": "ml:includes",
+    "recordSet": "ml:RecordSet",
+    "field": "ml:Field",
+    "subField": "ml:SubField",
+    "dataType": "ml:dataType",
+    "source": "ml:source",
+    "data": "ml:data",
+    "applyTransform": "ml:applyTransform",
+    "format": "ml:format",
+    "regex": "ml:regex",
+    "separator": "ml:separator"
   },
   "@type": "Dataset",
   "@language": "en",

--- a/python/format/src/tests/graphs/distribution_missing_property_content_url.json
+++ b/python/format/src/tests/graphs/distribution_missing_property_content_url.json
@@ -3,14 +3,17 @@
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
     "ml": "http://mlcommons.org/schema/",
-    "dataType": {
-      "@id": "ml:dataType",
-      "@type": "@id"
-    },
-    "recordSet": {
-      "@id": "ml:RecordSet",
-      "@type": "@id"
-    }
+    "includes": "ml:includes",
+    "recordSet": "ml:RecordSet",
+    "field": "ml:Field",
+    "subField": "ml:SubField",
+    "dataType": "ml:dataType",
+    "source": "ml:source",
+    "data": "ml:data",
+    "applyTransform": "ml:applyTransform",
+    "format": "ml:format",
+    "regex": "ml:regex",
+    "separator": "ml:separator"
   },
   "@type": "Dataset",
   "@language": "en",

--- a/python/format/src/tests/graphs/metadata_bad_type.json
+++ b/python/format/src/tests/graphs/metadata_bad_type.json
@@ -3,14 +3,17 @@
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
     "ml": "http://mlcommons.org/schema/",
-    "dataType": {
-      "@id": "ml:dataType",
-      "@type": "@id"
-    },
-    "recordSet": {
-      "@id": "ml:RecordSet",
-      "@type": "@id"
-    }
+    "includes": "ml:includes",
+    "recordSet": "ml:RecordSet",
+    "field": "ml:Field",
+    "subField": "ml:SubField",
+    "dataType": "ml:dataType",
+    "source": "ml:source",
+    "data": "ml:data",
+    "applyTransform": "ml:applyTransform",
+    "format": "ml:format",
+    "regex": "ml:regex",
+    "separator": "ml:separator"
   },
   "@type": "WRONG_TYPE",
   "@language": "en",

--- a/python/format/src/tests/graphs/metadata_missing_property_name.json
+++ b/python/format/src/tests/graphs/metadata_missing_property_name.json
@@ -3,14 +3,17 @@
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
     "ml": "http://mlcommons.org/schema/",
-    "dataType": {
-      "@id": "ml:dataType",
-      "@type": "@id"
-    },
-    "recordSet": {
-      "@id": "ml:RecordSet",
-      "@type": "@id"
-    }
+    "includes": "ml:includes",
+    "recordSet": "ml:RecordSet",
+    "field": "ml:Field",
+    "subField": "ml:SubField",
+    "dataType": "ml:dataType",
+    "source": "ml:source",
+    "data": "ml:data",
+    "applyTransform": "ml:applyTransform",
+    "format": "ml:format",
+    "regex": "ml:regex",
+    "separator": "ml:separator"
   },
   "@type": "mydataset",
   "@language": "en",

--- a/python/format/src/tests/graphs/mlfield_bad_type.json
+++ b/python/format/src/tests/graphs/mlfield_bad_type.json
@@ -3,18 +3,17 @@
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
     "ml": "http://mlcommons.org/schema/",
-    "dataType": {
-      "@id": "ml:dataType",
-      "@type": "@id"
-    },
-    "field": {
-      "@id": "ml:Field",
-      "@type": "@id"
-    },
-    "recordSet": {
-      "@id": "ml:RecordSet",
-      "@type": "@id"
-    }
+    "includes": "ml:includes",
+    "recordSet": "ml:RecordSet",
+    "field": "ml:Field",
+    "subField": "ml:SubField",
+    "dataType": "ml:dataType",
+    "source": "ml:source",
+    "data": "ml:data",
+    "applyTransform": "ml:applyTransform",
+    "format": "ml:format",
+    "regex": "ml:regex",
+    "separator": "ml:separator"
   },
   "@type": "Dataset",
   "@language": "en",

--- a/python/format/src/tests/graphs/mlfield_missing_property_name.json
+++ b/python/format/src/tests/graphs/mlfield_missing_property_name.json
@@ -3,18 +3,17 @@
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
     "ml": "http://mlcommons.org/schema/",
-    "dataType": {
-      "@id": "ml:dataType",
-      "@type": "@id"
-    },
-    "field": {
-      "@id": "ml:Field",
-      "@type": "@id"
-    },
-    "recordSet": {
-      "@id": "ml:RecordSet",
-      "@type": "@id"
-    }
+    "includes": "ml:includes",
+    "recordSet": "ml:RecordSet",
+    "field": "ml:Field",
+    "subField": "ml:SubField",
+    "dataType": "ml:dataType",
+    "source": "ml:source",
+    "data": "ml:data",
+    "applyTransform": "ml:applyTransform",
+    "format": "ml:format",
+    "regex": "ml:regex",
+    "separator": "ml:separator"
   },
   "@type": "Dataset",
   "@language": "en",

--- a/python/format/src/tests/graphs/recordset_bad_type.json
+++ b/python/format/src/tests/graphs/recordset_bad_type.json
@@ -3,18 +3,17 @@
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
     "ml": "http://mlcommons.org/schema/",
-    "dataType": {
-      "@id": "ml:dataType",
-      "@type": "@id"
-    },
-    "field": {
-      "@id": "ml:Field",
-      "@type": "@id"
-    },
-    "recordSet": {
-      "@id": "ml:RecordSet",
-      "@type": "@id"
-    }
+    "includes": "ml:includes",
+    "recordSet": "ml:RecordSet",
+    "field": "ml:Field",
+    "subField": "ml:SubField",
+    "dataType": "ml:dataType",
+    "source": "ml:source",
+    "data": "ml:data",
+    "applyTransform": "ml:applyTransform",
+    "format": "ml:format",
+    "regex": "ml:regex",
+    "separator": "ml:separator"
   },
   "@type": "Dataset",
   "@language": "en",

--- a/python/format/src/tests/graphs/recordset_missing_property_name.json
+++ b/python/format/src/tests/graphs/recordset_missing_property_name.json
@@ -3,18 +3,17 @@
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
     "ml": "http://mlcommons.org/schema/",
-    "dataType": {
-      "@id": "ml:dataType",
-      "@type": "@id"
-    },
-    "field": {
-      "@id": "ml:Field",
-      "@type": "@id"
-    },
-    "recordSet": {
-      "@id": "ml:RecordSet",
-      "@type": "@id"
-    }
+    "includes": "ml:includes",
+    "recordSet": "ml:RecordSet",
+    "field": "ml:Field",
+    "subField": "ml:SubField",
+    "dataType": "ml:dataType",
+    "source": "ml:source",
+    "data": "ml:data",
+    "applyTransform": "ml:applyTransform",
+    "format": "ml:format",
+    "regex": "ml:regex",
+    "separator": "ml:separator"
   },
   "@type": "Dataset",
   "@language": "en",

--- a/python/format/src/tests/graphs/valid.json
+++ b/python/format/src/tests/graphs/valid.json
@@ -3,18 +3,17 @@
     "@vocab": "https://schema.org/",
     "sc": "https://schema.org/",
     "ml": "http://mlcommons.org/schema/",
-    "dataType": {
-      "@id": "ml:dataType",
-      "@type": "@id"
-    },
-    "field": {
-      "@id": "ml:Field",
-      "@type": "@id"
-    },
-    "recordSet": {
-      "@id": "ml:RecordSet",
-      "@type": "@id"
-    }
+    "includes": "ml:includes",
+    "recordSet": "ml:RecordSet",
+    "field": "ml:Field",
+    "subField": "ml:SubField",
+    "dataType": "ml:dataType",
+    "source": "ml:source",
+    "data": "ml:data",
+    "applyTransform": "ml:applyTransform",
+    "format": "ml:format",
+    "regex": "ml:regex",
+    "separator": "ml:separator"
   },
   "@type": "Dataset",
   "@language": "en",


### PR DESCRIPTION
It is important to have a clean context referencing all `mlcommons` predicates.