### PR TITLE
Add a warning message when no `ml:RecordSet` or `sc:distribution` are defined

### DIFF
--- a/python/format/src/datasets_test.py
+++ b/python/format/src/datasets_test.py
@@ -17,6 +17,10 @@ import pytest
             "metadata_bad_type.json",
             'Node should have an attribute `"@type" in',
         ],
+        [
+            "metadata_bad_type.json",
+            'The current dataset doesn\'t declare any node of type: "http://mlcommons.org/schema/RecordSet"',
+        ],
         # Distribution.
         [
             "distribution_missing_property_content_url.json",

--- a/python/format/src/errors_test.py
+++ b/python/format/src/errors_test.py
@@ -12,44 +12,44 @@ def test_issues():
     with issues.context(dataset_name="abc"):
         issues.add_error("foo")
         issues.add_warning("bar")
-    assert issues.errors == ["[dataset(abc)] foo"]
-    assert issues.warnings == ["[dataset(abc)] bar"]
+    assert issues.errors == {"[dataset(abc)] foo"}
+    assert issues.warnings == {"[dataset(abc)] bar"}
 
     # With nested context
     with issues.context(dataset_name="abc", distribution_name="xyz"):
         issues.add_error("foo")
         issues.add_warning("bar")
-    assert issues.errors == [
+    assert issues.errors == {
         "[dataset(abc)] foo",
         "[dataset(abc) > distribution(xyz)] foo",
-    ]
-    assert issues.warnings == [
+    }
+    assert issues.warnings == {
         "[dataset(abc)] bar",
         "[dataset(abc) > distribution(xyz)] bar",
-    ]
+    }
 
     # Without context
     issues.add_error("foo")
     issues.add_warning("bar")
-    assert issues.errors == [
+    assert issues.errors == {
         "[dataset(abc)] foo",
         "[dataset(abc) > distribution(xyz)] foo",
         "foo",
-    ]
-    assert issues.warnings == [
+    }
+    assert issues.warnings == {
         "[dataset(abc)] bar",
         "[dataset(abc) > distribution(xyz)] bar",
         "bar"
-    ]
+    }
 
     # Final report
     assert issues.report() == textwrap.dedent(
         """Found the following 3 error(s) during the validation:
-  -  [dataset(abc)] foo
   -  [dataset(abc) > distribution(xyz)] foo
+  -  [dataset(abc)] foo
   -  foo
 Found the following 3 warning(s) during the validation:
-  -  [dataset(abc)] bar
   -  [dataset(abc) > distribution(xyz)] bar
+  -  [dataset(abc)] bar
   -  bar"""
     )

--- a/python/format/src/nodes.py
+++ b/python/format/src/nodes.py
@@ -189,6 +189,10 @@ class Node:
                         parent_uid=self.uid,
                     )
                 )
+        if not nodes and expected_property in [constants.ML_COMMONS_RECORD_SET, constants.SCHEMA_ORG_DISTRIBUTION]:
+            self.issues.add_warning(
+                f'The current dataset doesn\'t declare any node of type: "{expected_property}"'
+            )
         return nodes
 
     def assert_has_mandatory_properties(self, *mandatory_properties: list[str]):


### PR DESCRIPTION
Not defining `ml:RecordSet` or `sc:distribution` is often the consequence of a bad `@context`, so we want to let the user know.

In addition, we don't want to repeat this error, so we turned `Issues` into sets (instead of lists).