### PR TITLE
Add widgets for Python version and CI/CD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Datasets format
+# 🥐 Croissant
+
+[![CI](https://github.com/mlcommons/datasets_format/actions/workflows/ci.yml/badge.svg)](https://github.com/mlcommons/datasets_format/actions/workflows/ci.yml/badge.svg)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
+
+## Working group
 
 [Drive folder](https://drive.google.com/corp/drive/folders/0AJdoVnszz6OVUk9PVA) with meeting notes, concept, requirements, spec, etc.
-
 
 Mailing list: https://groups.google.com/g/mldsformat/


### PR DESCRIPTION
We only support Python>=3.10, issue https://github.com/mlcommons/datasets_format/issues/28 should fix this and support Python>=3.8.